### PR TITLE
Chunk source URIs when creating assets

### DIFF
--- a/app/tasks/batch.py
+++ b/app/tasks/batch.py
@@ -10,6 +10,8 @@ from ..models.pydantic.change_log import ChangeLog
 from ..models.pydantic.jobs import Job
 from ..utils.aws import get_batch_client
 
+BATCH_DEPENDENCY_LIMIT = 20
+
 
 async def execute(jobs: List[Job],) -> ChangeLog:
     try:

--- a/batch/scripts/get_arguments.sh
+++ b/batch/scripts/get_arguments.sh
@@ -112,7 +112,7 @@ do
       shift # past value
       ;;
       -s|--source)
-      SRC="$2"
+      SRC+=("$2")
       shift # past argument
       shift # past value
       ;;

--- a/batch/scripts/load_tabular_data.sh
+++ b/batch/scripts/load_tabular_data.sh
@@ -16,5 +16,6 @@ if [ "$DELIMITER" == "\t" ]; then
   DELIMITER=$(echo -e "\t")
 fi
 
-aws s3 cp "${SRC}" - | psql -c "COPY \"$DATASET\".\"$VERSION\" FROM STDIN WITH (FORMAT CSV, DELIMITER '$DELIMITER', HEADER)"
-
+for uri in "${SRC[@]}"; do
+  aws s3 cp "${uri}" - | psql -c "COPY \"$DATASET\".\"$VERSION\" FROM STDIN WITH (FORMAT CSV, DELIMITER '$DELIMITER', HEADER)"
+done

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,7 @@
 import contextlib
 import threading
+import csv
+import io
 from http.server import HTTPServer
 
 import boto3
@@ -159,3 +161,15 @@ def copy_fixtures():
     s3_client.upload_file(GEOJSON_PATH, BUCKET, GEOJSON_NAME)
     s3_client.upload_file(TSV_PATH, BUCKET, TSV_NAME)
     s3_client.upload_file(SHP_PATH, BUCKET, SHP_NAME)
+
+    # upload a separate for each row so we can test running large numbers of sources in parallel
+    reader = csv.DictReader(open(TSV_PATH, newline=''), delimiter='\t')
+    for row in reader:
+        out = io.StringIO()
+        writer = csv.writer(out, delimiter='\t')
+        writer.writerow(reader.fieldnames)
+        writer.writerow(row.values())
+
+        s3_client.upload_fileobj(out, BUCKET, f"test_{reader.line_num}.tsv")
+        out.close()
+

--- a/tests/tasks/test_default_assets.py
+++ b/tests/tasks/test_default_assets.py
@@ -233,6 +233,146 @@ async def test_table_source_asset(batch_client, httpd):
     assert cluster_count == len(partition_schema)
 
 
+@pytest.mark.asyncio
+async def test_table_source_asset_parallel(batch_client, httpd):
+    _, logs = batch_client
+    httpd_port = httpd.server_port
+
+    ############################
+    # Setup test
+    ############################
+
+    s3_client = get_s3_client()
+
+    s3_client.create_bucket(Bucket=BUCKET)
+    s3_client.upload_file(TSV_PATH, BUCKET, TSV_NAME)
+
+    dataset = "table_test"
+    version = "v202002.1"
+
+    # define partition schema
+    partition_schema = list()
+    years = range(2018, 2021)
+    for year in years:
+        for week in range(1, 54):
+            try:
+                name = f"y{year}_w{week:02}"
+                start = pendulum.parse(f"{year}-W{week:02}").to_date_string()
+                end = pendulum.parse(f"{year}-W{week:02}").add(days=7).to_date_string()
+                partition_schema.append(
+                    {"partition_suffix": name, "start_value": start, "end_value": end}
+                )
+
+            except ParserError:
+                # Year has only 52 weeks
+                pass
+
+    input_data = {
+        "source_type": "table",
+        "source_uri": [f"s3://{BUCKET}/{TSV_NAME}"] + [f"s3://{BUCKET}/test_{i}.tsv" for i in range(2, 101)],
+        "creation_options": {
+            "src_driver": "text",
+            "delimiter": "\t",
+            "has_header": True,
+            "latitude": "latitude",
+            "longitude": "longitude",
+            "cluster": {"index_type": "gist", "column_name": "geom_wm"},
+            "partitions": {
+                "partition_type": "range",
+                "partition_column": "alert__date",
+                "partition_schema": partition_schema,
+            },
+            "indices": [
+                {"index_type": "gist", "column_name": "geom"},
+                {"index_type": "gist", "column_name": "geom_wm"},
+                {"index_type": "btree", "column_name": "alert__date"},
+            ],
+            "table_schema": [
+                {
+                    "field_name": "rspo_oil_palm__certification_status",
+                    "field_type": "text",
+                },
+                {"field_name": "per_forest_concession__type", "field_type": "text"},
+                {"field_name": "idn_forest_area__type", "field_type": "text"},
+                {"field_name": "alert__count", "field_type": "integer"},
+                {"field_name": "adm1", "field_type": "integer"},
+                {"field_name": "adm2", "field_type": "integer"},
+            ],
+        },
+        "metadata": {},
+    }
+
+    await create_dataset(dataset)
+    await create_version(dataset, version, input_data)
+
+    #####################
+    # Test asset creation
+    #####################
+
+    # Create default asset in mocked BATCH
+    async with ContextEngine("WRITE"):
+        asset_id = await create_default_asset(dataset, version, input_data, None,)
+
+    tasks_rows = await tasks.get_tasks(asset_id)
+    task_ids = [str(task.task_id) for task in tasks_rows]
+
+    # make sure, all jobs completed
+    status = await poll_jobs(task_ids)
+
+    # Get the logs in case something went wrong
+    _print_logs(logs)
+    check_callbacks(task_ids, httpd_port)
+
+    assert status == "saved"
+
+    await _check_version_status(dataset, version)
+    await _check_asset_status(dataset, version, 1)
+    await _check_task_status(asset_id, 33, "cluster_partitions_3")
+
+    # There should be a table called "table_test"."v202002.1" with 99 rows.
+    # It should have the right amount of partitions and indices
+    async with ContextEngine("READ"):
+        count = await db.scalar(
+            db.text(
+                f"""
+                    SELECT count(*)
+                        FROM "{dataset}"."{version}";"""
+            )
+        )
+        partition_count = await db.scalar(
+            db.text(
+                f"""
+                    SELECT count(i.inhrelid::regclass)
+                        FROM pg_inherits i
+                        WHERE  i.inhparent = '"{dataset}"."{version}"'::regclass;"""
+            )
+        )
+        index_count = await db.scalar(
+            db.text(
+                f"""
+                    SELECT count(indexname)
+                        FROM pg_indexes
+                        WHERE schemaname = '{dataset}' AND tablename like '{version}%';"""
+            )
+        )
+        cluster_count = await db.scalar(
+            db.text(
+                """
+                    SELECT count(relname)
+                        FROM   pg_class c
+                        JOIN   pg_index i ON i.indrelid = c.oid
+                        WHERE  relkind = 'r' AND relhasindex AND i.indisclustered"""
+            )
+        )
+
+    assert count == 99
+    assert partition_count == len(partition_schema)
+    assert index_count == partition_count * len(
+        input_data["creation_options"]["indices"]
+    )
+    assert cluster_count == len(partition_schema)
+
+
 def _assert_fields(field_list, field_schema):
     count = 0
     for field in field_list:


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [X] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [X] Check the commit's or even all commits' message styles matches our requested structure.
- [X] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

Please check the type of change your PR introduces:
- [X] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
Each source URI when creating a table asset is load to the db in a parallel batch job. These batch jobs are then the dependencies for other batch jobs in the pipeline. However, AWS Batch has a limit of 20 jobs as dependencies, so this break if there are more than 20 source URIs.


## What is the new behavior?
Chunk the source URIs so that there's never more than 20 chunks. These chunks will get loaded to the db in the same batch job.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

## Notes

I think this fixes the issue. It should still run jobs in parallel if there's <20 source URIs, but if there's more, it'll break than down into parallel chunks that stay in the limit. I made a new test that's just the same as test_table_source_asset, but I mock upload 99 files to S3, one for each row in test.tsv (so it's not super slow). This seems to work, let me know if it doesn't seem like a valid test.