### PR TITLE
Remove carriage returns from the end of line when loading tabular data

### DIFF
--- a/batch/scripts/load_tabular_data.sh
+++ b/batch/scripts/load_tabular_data.sh
@@ -21,8 +21,8 @@ for uri in "${SRC[@]}"; do
   FIELDS=$(aws s3 cp "${uri}" - | head -1)
   set -e
 
-  FIELDS=$(sed -e $'s/\\t/,/g' -e 's/^/"/;s/$/"/' -e 's/,/","/g' <<< $FIELDS)
+  FIELDS=$(sed -e $'s/\\t/,/g' -e 's/^/"/;s/$/"/' -e 's/,/","/g' -e 's/\r$//' <<< $FIELDS)
   FIELDS="($FIELDS)"
 
-  aws s3 cp "${uri}" - | psql -c "COPY \"$DATASET\".\"$VERSION\" $FIELDS FROM STDIN WITH (FORMAT CSV, DELIMITER '$DELIMITER', HEADER)"
+  aws s3 cp "${uri}" - | sed -e 's/\r$//' | psql -c "COPY \"$DATASET\".\"$VERSION\" $FIELDS FROM STDIN WITH (FORMAT CSV, DELIMITER '$DELIMITER', HEADER)"
 done

--- a/terraform/docker/docker-compose.yml
+++ b/terraform/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 services:
   terraform:
-    image: globalforestwatch/terraform:1.2.1
+    image: globalforestwatch/terraform:1.2.2
     volumes:
       - ../../:/usr/local/src
       - $HOME/.aws:/root/.aws:ro


### PR DESCRIPTION
Remove carriage returns from the end of line when loading tabular data. This can come from files on Windows machines, and cause weird issues when we load it on linux

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [X] Check the commit's or even all commits' message styles matches our requested structure.
- [X] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: GTC-825


## What is the new behavior?

- Remove return carriages from all lines when reading them

## Does this introduce a breaking change?

- [ ] Yes
- [X] No
