### PR TITLE
Add retry logic to 1x1 tile export

### DIFF
--- a/batch/python/export_1x1_grid.py
+++ b/batch/python/export_1x1_grid.py
@@ -7,6 +7,7 @@ from asyncio import AbstractEventLoop
 from typing import List, Set, Tuple
 
 import asyncpg
+from asyncpg.exceptions import ConnectionDoesNotExistError
 from sqlalchemy import Table, column, literal_column, select, table, text
 from sqlalchemy.sql import Select
 from sqlalchemy.sql.elements import TextClause
@@ -385,21 +386,37 @@ async def run(
         grid_id: str = tile[0]
         tcl: bool = tile[1]
         glad: bool = tile[2]
-        con = await asyncpg.connect(
-            user=PGUSER,
-            database=PGDATABASE,
-            host=PGHOST,
-            port=PGPORT,
-            password=PGPASSWORD,
-        )
-        result = await con.copy_from_query(
-            str(get_sql(dataset, version, fields, grid_id, tcl, glad)),
-            output=output,
-            format="csv",
-            delimiter="\t",
-            header=header,
-        )
-        print(result)
+
+        retries = 0
+        success = False
+
+        while not success and retries < 2:
+            try:
+                con = await asyncpg.connect(
+                    user=PGUSER,
+                    database=PGDATABASE,
+                    host=PGHOST,
+                    port=PGPORT,
+                    password=PGPASSWORD,
+                )
+                result = await con.copy_from_query(
+                    str(get_sql(dataset, version, fields, grid_id, tcl, glad)),
+                    output=output,
+                    format="csv",
+                    delimiter="\t",
+                    header=header,
+                )
+                print(result)
+
+                await con.close()
+                success = True
+            except ConnectionDoesNotExistError:
+                print("warning: Connection to DB lost during operation, retrying...")
+                retries += 1
+
+        if retries >= 2:
+            raise Exception("error: failed with ConnectionDoesNotExistError after multiple retries")
+
 
     max_tasks: int = MAX_TASKS
     tasks: Set = set()


### PR DESCRIPTION


## Pull request checklist

Please check if your PR fulfills the following requirements:
- X ] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [ ] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [X] Check the commit's or even all commits' message styles matches our requested structure.
- [X] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
If connection to DB gets interrupted during export of tiles to 1x1 , that tile will just fail. 



## What is the new behavior?

- Retry twice if connection for a tile export fails
- Always close connection after finishing

## Does this introduce a breaking change?

- [ ] Yes
- [X] No


