### PR TITLE
Change creation_options endpoint to use JSONResponse

### DIFF
--- a/app/routes/assets/asset.py
+++ b/app/routes/assets/asset.py
@@ -13,6 +13,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Path
 from fastapi.responses import ORJSONResponse
+from starlette.responses import JSONResponse
 
 from ...crud import assets, tasks
 from ...errors import RecordNotFoundError
@@ -199,11 +200,13 @@ async def get_change_log(asset_id: UUID = Path(...)):
 
 @router.get(
     "/{asset_id}/creation_options",
-    response_class=ORJSONResponse,
+    response_class=JSONResponse,
     tags=["Assets"],
     response_model=CreationOptionsResponse,
 )
 async def get_creation_options(asset_id: UUID = Path(...)):
+    # Not using ORJSONResponse because orjson won't serialize the numeric
+    # keys in a Symbology object
     asset: ORMAsset = await assets.get_asset(asset_id)
     creation_options: CreationOptions = creation_option_factory(
         asset.asset_type, asset.creation_options

--- a/tests/routes/test_assets.py
+++ b/tests/routes/test_assets.py
@@ -496,6 +496,11 @@ async def _test_raster_tile_cache(
     asset_resp = await async_client.get(f"/asset/{tile_cache_asset_id}")
     assert asset_resp.json()["data"]["status"] == "saved"
 
+    # Make sure the creation_options endpoint works (verify that the bug
+    # with numeric keys in colormap is fixed, GTC-974):
+    c_o_resp = await async_client.get(f"/asset/{tile_cache_asset_id}/creation_options")
+    assert c_o_resp.json()["status"] == "success"
+
     # Check if file for all expected assets are present
     for pixel_meaning in wm_tile_set_assets:
         test_files = [


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [x] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Hitting the creation_options endpoint for a raster tile cache with a color map yields an exception

Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- The creation_options endpoint returns the creation_options even for a raster tile cache with a color map
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
