### PR TITLE
Dramatically reduce memory usage of histogram merging

### DIFF
--- a/app/utils/stats.py
+++ b/app/utils/stats.py
@@ -6,25 +6,29 @@ from pydantic import StrictFloat, StrictInt
 from app.models.pydantic.statistics import Histogram
 
 
-def _reconstruct_bins(
+def _reconstruct_edges(
     min_val: Union[StrictInt, float],
     max_val: Union[StrictInt, float],
     num_bins: StrictInt,
 ) -> List[Union[StrictInt, float]]:
+    """Returns the reconstructed edges of a histogram."""
     return np.linspace(min_val, max_val, num=num_bins)
 
 
 def _extract_vals(histo: Histogram) -> List[Union[StrictInt, StrictFloat]]:
-    reconstructed_bins = _reconstruct_bins(histo.min, histo.max, histo.bin_count)
+    """Returns an *approximation* of the original values represented in the
+    histogram."""
+    reconstructed_edges = _reconstruct_edges(histo.min, histo.max, histo.bin_count)
     reconstructed_values = [
-        [d] * c for c, d in zip(histo.value_count, reconstructed_bins)
+        [d] * c for c, d in zip(histo.value_count, reconstructed_edges)
     ]
-    # Return flattened list.
+    # Return a flattened list.
     return [z for s in reconstructed_values for z in s]
 
 
-def _extract_bin_resolution(reconstructed_values: List[Union[StrictInt, StrictFloat]]):
-    return reconstructed_values[1] - reconstructed_values[0]
+def _extract_bin_resolution(reconstructed_edges: List[Union[StrictInt, StrictFloat]]):
+    """Return the 'size' of a bin, assumes bins are uniformly spaced."""
+    return reconstructed_edges[1] - reconstructed_edges[0]
 
 
 def _generate_num_bins(minval, maxval, bin_res) -> StrictInt:
@@ -43,27 +47,37 @@ def merge_n_histograms(histos: List[Histogram]) -> Optional[Histogram]:
     if len(histos) == 1:
         return histos[0]
 
-    all_vals: List[Union[StrictInt, StrictFloat]] = []
-    for histo in histos:
-        all_vals.extend(_extract_vals(histo))
-
-    all_bins = [
-        _reconstruct_bins(histo.min, histo.max, histo.bin_count) for histo in histos
-    ]
-
-    min_bin_resolution = min([_extract_bin_resolution(bins) for bins in all_bins])
-    # print(f"New histogram bin resolution is: {min_bin_resolution}")
-
+    # Find the min and max of all histograms to be merged, to be used as the
+    # new min and max of the final histogram
     new_min = min(*[histo.min for histo in histos])
     # print(f"New histogram min is: {new_min}")
 
     new_max = max(*[histo.max for histo in histos])
     # print(f"New histogram max is: {new_max}")
 
-    num_bins = _generate_num_bins(new_min, new_max, min_bin_resolution)
-    # print(f"New histogram size is: {num_bins}")
+    # Approximate the structure of the original histograms in order to find
+    # the overall minimum bin spacing needed to accurately differentiate
+    # bins. Use this to figure out how many bins will be required in the
+    # final histogram
+    all_bins = [
+        _reconstruct_edges(histo.min, histo.max, histo.bin_count) for histo in histos
+    ]
+    min_bin_resolution = min([_extract_bin_resolution(bins) for bins in all_bins])
+    # print(f"New histogram bin size is: {min_bin_resolution}")
 
-    np_histo = np.histogram(all_vals, bins=num_bins)
+    num_bins = _generate_num_bins(new_min, new_max, min_bin_resolution)
+    # print(f"Number of bins in new histogram is: {num_bins}")
+
+    # Reconstruct approximate values for each feature and create a histogram
+    # with the new min, max, and number of bins. Then because the parameters
+    # are the same we can add the histogram, element-wise, into a final
+    # histogram.
+    final_np_histo = np.histogram([], bins=num_bins, range=(new_min, new_max))
+    for histo in histos:
+        histo_vals = _extract_vals(histo)
+        np_histo = np.histogram(histo_vals, bins=num_bins, range=(new_min, new_max))
+        for i, new_vals in enumerate(np_histo[0]):
+            final_np_histo[0][i] += new_vals
 
     # np.histogram actually produces an array of type numpy.int64, but
     # our Histograms are picky about datatype
@@ -71,5 +85,5 @@ def merge_n_histograms(histos: List[Histogram]) -> Optional[Histogram]:
         min=new_min,
         max=new_max,
         bin_count=num_bins,
-        value_count=[StrictInt(x) for x in np_histo[0]],
+        value_count=[StrictInt(x) for x in final_np_histo[0]],
     )


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [x] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Merging histograms requires an excessive amount of memory - on the order of the original dataset.
This often causes OOM issues.

Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Merging histograms requires memory on the order of the largest feature
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
