### PR TITLE
give pixetl more time to process float data types and run on larger i…

### DIFF
--- a/app/models/pydantic/creation_options.py
+++ b/app/models/pydantic/creation_options.py
@@ -118,6 +118,12 @@ class RasterTileSetSourceCreationOptions(RasterTileSetAssetCreationOptions):
     )
 
 
+class PixETLCreationOptions(RasterTileSetAssetCreationOptions):
+    # For internal use only
+    source_type: Union[RasterSourceType, VectorSourceType]
+    source_driver: Optional[RasterDrivers] = None
+
+
 class VectorSourceCreationOptions(StrictBaseModel):
     source_type: VectorSourceType = Field(..., description="Source type of input file.")
     source_driver: VectorDrivers = Field(

--- a/app/models/pydantic/creation_options.py
+++ b/app/models/pydantic/creation_options.py
@@ -108,20 +108,20 @@ class RasterTileSetAssetCreationOptions(StrictBaseModel):
     process_locally: bool = True
 
 
-class RasterTileSetSourceCreationOptions(RasterTileSetAssetCreationOptions):
-    source_type: RasterSourceType = Field(..., description="Source type of input file.")
-    source_driver: RasterDrivers = Field(
-        ..., description="Driver of source file. Must be an OGR driver"
-    )
+class PixETLCreationOptions(RasterTileSetAssetCreationOptions):
+    # For internal use only
+    source_type: Union[RasterSourceType, VectorSourceType]
+    source_driver: Optional[RasterDrivers] = None
     source_uri: Optional[List[str]] = Field(
         description="List of input files. Must be s3:// URLs.",
     )
 
 
-class PixETLCreationOptions(RasterTileSetAssetCreationOptions):
-    # For internal use only
-    source_type: Union[RasterSourceType, VectorSourceType]
-    source_driver: Optional[RasterDrivers] = None
+class RasterTileSetSourceCreationOptions(PixETLCreationOptions):
+    source_type: RasterSourceType = Field(..., description="Source type of input file.")
+    source_driver: RasterDrivers = Field(
+        ..., description="Driver of source file. Must be an OGR driver"
+    )
 
 
 class VectorSourceCreationOptions(StrictBaseModel):

--- a/app/models/pydantic/jobs.py
+++ b/app/models/pydantic/jobs.py
@@ -5,6 +5,7 @@ from pydantic import validator
 from ...settings.globals import (
     AURORA_JOB_QUEUE,
     DATA_LAKE_JOB_QUEUE,
+    DEFAULT_JOB_DURATION,
     GDAL_PYTHON_JOB_DEFINITION,
     MAX_CORES,
     MAX_MEM,
@@ -72,7 +73,7 @@ class PostgresqlClientJob(Job):
     vcpus = 1
     memory = 1500
     attempts = 1
-    attempt_duration_seconds = 7500
+    attempt_duration_seconds = DEFAULT_JOB_DURATION
 
 
 class GdalPythonImportJob(Job):
@@ -84,7 +85,7 @@ class GdalPythonImportJob(Job):
     vcpus = 1
     memory = 2500
     attempts = 1
-    attempt_duration_seconds = 7500
+    attempt_duration_seconds = DEFAULT_JOB_DURATION
 
 
 class GdalPythonExportJob(Job):
@@ -96,7 +97,7 @@ class GdalPythonExportJob(Job):
     vcpus = 1
     memory = 15000
     attempts = 1
-    attempt_duration_seconds = 7500
+    attempt_duration_seconds = DEFAULT_JOB_DURATION
 
 
 class TileCacheJob(Job):
@@ -107,8 +108,7 @@ class TileCacheJob(Job):
     vcpus = 48
     memory = 96000
     attempts = 4
-    attempt_duration_seconds = 10800
-
+    attempt_duration_seconds = int(DEFAULT_JOB_DURATION * 1.5)
 
 
 class PixETLJob(Job):
@@ -119,7 +119,7 @@ class PixETLJob(Job):
     vcpus = PIXETL_CORES
     memory = PIXETL_MAX_MEM
     attempts = 4
-    attempt_duration_seconds = 9600
+    attempt_duration_seconds = int(DEFAULT_JOB_DURATION * 1.5)
 
 
 class BuildRGBJob(Job):
@@ -130,7 +130,7 @@ class BuildRGBJob(Job):
     vcpus = MAX_CORES
     memory = MAX_MEM
     attempts = 4
-    attempt_duration_seconds = 7500
+    attempt_duration_seconds = DEFAULT_JOB_DURATION
 
 
 class GDAL2TilesJob(Job):
@@ -141,4 +141,4 @@ class GDAL2TilesJob(Job):
     vcpus = MAX_CORES
     memory = MAX_MEM
     attempts = 4
-    attempt_duration_seconds = 7500
+    attempt_duration_seconds = DEFAULT_JOB_DURATION

--- a/app/settings/globals.py
+++ b/app/settings/globals.py
@@ -118,12 +118,12 @@ AURORA_JOB_QUEUE_FAST = config("AURORA_JOB_QUEUE_FAST", cast=str)
 DATA_LAKE_JOB_QUEUE = config("DATA_LAKE_JOB_QUEUE", cast=str)
 TILE_CACHE_JOB_DEFINITION = config("TILE_CACHE_JOB_DEFINITION", cast=str)
 TILE_CACHE_JOB_QUEUE = config("TILE_CACHE_JOB_QUEUE", cast=str)
-MAX_CORES = config("MAX_CORES", cast=int, default=48)
-MAX_MEM = config("MAX_MEM", cast=int, default=380000)
+MAX_CORES = config("MAX_CORES", cast=int, default=96)
+MAX_MEM = config("MAX_MEM", cast=int, default=760000)
 PIXETL_JOB_DEFINITION = config("PIXETL_JOB_DEFINITION", cast=str)
 PIXETL_JOB_QUEUE = config("PIXETL_JOB_QUEUE", cast=str)
-PIXETL_CORES = config("PIXETL_CORES", cast=int, default=MAX_CORES)
-PIXETL_MAX_MEM = config("PIXETL_MAX_MEM", cast=int, default=MAX_MEM)
+PIXETL_CORES = config("PIXETL_CORES", cast=int, default=48)
+PIXETL_MAX_MEM = config("PIXETL_MAX_MEM", cast=int, default=380000)
 PIXETL_DEFAULT_RESAMPLING = config(
     "DEFAULT_RESAMPLING", cast=str, default=ResamplingMethod.nearest.value
 )
@@ -155,3 +155,6 @@ RW_API_URL = (
     if ENV == "production"
     else "https://staging-api.resourcewatch.org"
 )
+
+HOUR: int = int(60 * 60)
+DEFAULT_JOB_DURATION: int = int(HOUR * 2)

--- a/app/tasks/raster_tile_cache_assets/utils.py
+++ b/app/tasks/raster_tile_cache_assets/utils.py
@@ -6,10 +6,7 @@ from fastapi.logger import logger
 from app.crud.assets import create_asset
 from app.models.enum.assets import AssetType
 from app.models.pydantic.assets import AssetCreateIn
-from app.models.pydantic.creation_options import (
-    PixETLCreationOptions,
-    RasterTileSetSourceCreationOptions,
-)
+from app.models.pydantic.creation_options import RasterTileSetSourceCreationOptions
 from app.models.pydantic.jobs import GDAL2TilesJob, Job
 from app.models.pydantic.metadata import RasterTileSetMetadata
 from app.settings.globals import MAX_CORES, MAX_MEM, TILE_CACHE_BUCKET
@@ -99,7 +96,7 @@ async def create_wm_tile_set_job(
     job = await create_pixetl_job(
         dataset,
         version,
-        PixETLCreationOptions(**creation_options.dict()),
+        creation_options,
         job_name,
         callback_constructor(wm_asset_record.asset_id),
         parents=parents,

--- a/app/tasks/raster_tile_cache_assets/utils.py
+++ b/app/tasks/raster_tile_cache_assets/utils.py
@@ -96,7 +96,7 @@ async def create_wm_tile_set_job(
     job = await create_pixetl_job(
         dataset,
         version,
-        wm_asset_record.creation_options,
+        creation_options,
         job_name,
         callback_constructor(wm_asset_record.asset_id),
         parents=parents,

--- a/app/tasks/raster_tile_cache_assets/utils.py
+++ b/app/tasks/raster_tile_cache_assets/utils.py
@@ -6,7 +6,10 @@ from fastapi.logger import logger
 from app.crud.assets import create_asset
 from app.models.enum.assets import AssetType
 from app.models.pydantic.assets import AssetCreateIn
-from app.models.pydantic.creation_options import RasterTileSetSourceCreationOptions
+from app.models.pydantic.creation_options import (
+    PixETLCreationOptions,
+    RasterTileSetSourceCreationOptions,
+)
 from app.models.pydantic.jobs import GDAL2TilesJob, Job
 from app.models.pydantic.metadata import RasterTileSetMetadata
 from app.settings.globals import MAX_CORES, MAX_MEM, TILE_CACHE_BUCKET
@@ -96,7 +99,7 @@ async def create_wm_tile_set_job(
     job = await create_pixetl_job(
         dataset,
         version,
-        creation_options,
+        PixETLCreationOptions(**creation_options.dict()),
         job_name,
         callback_constructor(wm_asset_record.asset_id),
         parents=parents,

--- a/app/tasks/raster_tile_set_assets/utils.py
+++ b/app/tasks/raster_tile_set_assets/utils.py
@@ -1,14 +1,17 @@
-import copy
 import json
-from typing import Any, Dict, List, Optional
+from typing import List, Optional
 
 from fastapi.encoders import jsonable_encoder
 
+from app.models.pydantic.creation_options import RasterTileSetSourceCreationOptions
 from app.models.pydantic.jobs import Job, PixETLJob
 from app.settings.globals import (
     AWS_GCS_KEY_SECRET_ARN,
     AWS_REGION,
+    DEFAULT_JOB_DURATION,
     ENV,
+    MAX_CORES,
+    MAX_MEM,
     S3_ENTRYPOINT_URL,
 )
 from app.tasks import Callback, writer_secrets
@@ -34,14 +37,14 @@ if S3_ENTRYPOINT_URL:
 async def create_pixetl_job(
     dataset: str,
     version: str,
-    co: Dict[str, Any],
+    co: RasterTileSetSourceCreationOptions,
     job_name: str,
     callback: Callback,
     parents: Optional[List[Job]] = None,
 ) -> Job:
     """Schedule a PixETL Batch Job."""
-    co_copy = copy.deepcopy(co)
-    if isinstance(co_copy.get("source_uri"), list):
+    co_copy = co.dict(exclude_none=True, by_alias=True)
+    if isinstance(co.source_uri, list):
         co_copy["source_uri"] = co_copy["source_uri"][0]
     overwrite = co_copy.pop("overwrite", False)
     subset = co_copy.pop("subset", None)
@@ -63,10 +66,21 @@ async def create_pixetl_job(
     if subset:
         command += ["--subset", subset]
 
+    # allowing float jobs to run longer
+    if "float" in co.data_type:
+        kwargs = {
+            "attempt_duration_seconds": int(DEFAULT_JOB_DURATION * 3),
+            "vcpus": MAX_CORES,
+            "memory": MAX_MEM,
+        }
+    else:
+        kwargs = {}
+
     return PixETLJob(
         job_name=job_name,
         command=command,
         environment=JOB_ENV,
         callback=callback,
         parents=[parent.job_name for parent in parents] if parents else None,
+        **kwargs
     )

--- a/app/tasks/raster_tile_set_assets/utils.py
+++ b/app/tasks/raster_tile_set_assets/utils.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 
 from fastapi.encoders import jsonable_encoder
 
-from app.models.pydantic.creation_options import RasterTileSetSourceCreationOptions
+from app.models.pydantic.creation_options import PixETLCreationOptions
 from app.models.pydantic.jobs import Job, PixETLJob
 from app.settings.globals import (
     AWS_GCS_KEY_SECRET_ARN,
@@ -37,7 +37,7 @@ if S3_ENTRYPOINT_URL:
 async def create_pixetl_job(
     dataset: str,
     version: str,
-    co: RasterTileSetSourceCreationOptions,
+    co: PixETLCreationOptions,
     job_name: str,
     callback: Callback,
     parents: Optional[List[Job]] = None,


### PR DESCRIPTION
…nstances, use pass creation option model to pixetl job, not dict

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [X] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [X] Check the commit's or even all commits' message styles matches our requested structure.
- [X] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 
- PixETL jobs with Float data types frequently run into timeouts


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- increase job duration time and instance capacity for float data types

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
