### PR TITLE
Limit number of parents of load_vector_data_jobs

### DIFF
--- a/app/tasks/utils.py
+++ b/app/tasks/utils.py
@@ -3,6 +3,26 @@ import string
 ALLOWABLE_CHARS = set(string.ascii_letters + string.digits + "-" + "_")
 
 
+class RingOfLists:
+    def __init__(self, size):
+        self._size = size
+        self._lists = [list() for i in range(0, size)]
+        self._idx = -1
+
+    def __next__(self):
+        self._idx += 1
+        if self._idx >= self._size:
+            self._idx = 0
+        return self._lists[self._idx]
+
+    def __iter__(self):
+        self.idx = -1
+        return self
+
+    def all(self):
+        return self._lists
+
+
 def sanitize_batch_job_name(proposed_name: str) -> str:
     """Make a string acceptable as an AWS Batch job name According to AWS docs,
     the first character must be alphanumeric, the name can be up to 128

--- a/app/tasks/vector_source_assets.py
+++ b/app/tasks/vector_source_assets.py
@@ -99,7 +99,7 @@ async def vector_source_asset(
     gfw_attribute_job = PostgresqlClientJob(
         job_name="enrich_gfw_attributes",
         command=["add_gfw_fields.sh", "-d", dataset, "-v", version],
-        parents=[queue[-1].job_name for queue in job_queues.all()],
+        parents=[queue[-1].job_name for queue in job_queues.all() if queue],
         environment=job_env,
         callback=callback,
     )

--- a/tests/routes/datasets/test_assets.py
+++ b/tests/routes/datasets/test_assets.py
@@ -11,9 +11,10 @@ from app.crud import tasks
 from app.crud.assets import update_asset
 from app.models.enum.creation_options import ColorMapType
 from app.models.pydantic.jobs import GDAL2TilesJob, GDALDEMJob, PixETLJob
-from app.settings.globals import DATA_LAKE_BUCKET, TILE_CACHE_BUCKET
+from app.settings.globals import TILE_CACHE_BUCKET
 from app.tasks.utils import sanitize_batch_job_name
 from app.utils.aws import get_s3_client
+from tests import BUCKET, DATA_LAKE_BUCKET, SHP_NAME
 from tests.conftest import FAKE_FLOAT_DATA_PARAMS, FAKE_INT_DATA_PARAMS
 from tests.tasks import MockCloudfrontClient
 from tests.utils import (
@@ -87,6 +88,64 @@ async def test_assets(async_client):
     assert create_asset_resp.json()["message"] == (
         "Version status is `failed`. Cannot add any assets."
     )
+
+
+@pytest.mark.asyncio
+async def test_assets_vector_source_max_parents(async_client):
+    """Make sure that vector source assets with > 20 layers stay within AWS
+    parents limit."""
+    # Add a dataset, version, and default asset
+    dataset = "test_vector_source_max_parents"
+    version = "v20210310"
+
+    vector_source_payload = {
+        "metadata": {},
+        "creation_options": {
+            "source_type": "vector",
+            "source_uri": [f"s3://{BUCKET}/{SHP_NAME}"],
+            "source_driver": "ESRI Shapefile",
+            "layers": [
+                "aus_plant",
+                "chl_plant",
+                "chn_plant",
+                "civ_plant",
+                "cmr_plant",
+                "cod_plant",
+                "col_plant",
+                "cri_plant",
+                "ecu_plant",
+                "eu_plant",
+                "gab_plant",
+                "gha_plant",
+                "gtm_plant",
+                "hnd_plant",
+                "idn_plant",
+                "ind_plant",
+                "jpn_plant",
+                "ken_plant",
+                "khm_plant",
+                "kor_plant",
+                "lbr_plant",
+                "lka_plant",
+                "mex_plant",
+            ],
+        },
+    }
+
+    with patch(
+        "app.tasks.batch.submit_batch_job", side_effect=generate_uuid
+    ) as mock_submit:
+        _ = await create_default_asset(
+            dataset,
+            version,
+            async_client=async_client,
+            version_payload=vector_source_payload,
+            execute_batch_jobs=True,
+        )
+
+    for mock_call in mock_submit.call_args_list:
+        job_obj = mock_call[0][0]
+        assert len(job_obj.parents) <= 19
 
 
 @pytest.mark.hanging
@@ -923,16 +982,8 @@ async def test_asset_float(async_client, batch_client, httpd):
                 job_obj.parents,
             )
             gdaldem_jobs[job_obj.job_name] = job
-        # else:
-        #     raise Exception("Unknown job type found")
-
-    print("GDALDEM JOBS:")
-    for job_name, deets in gdaldem_jobs.items():
-        print(f"{job_name}: {deets}")
-
-    print("PIXETL JOBS:")
-    for job_name, deets in pixetl_jobs.items():
-        print(f"{job_name}: {deets}")
+        else:
+            raise Exception("Unknown job type found")
 
     assert pixetl_jobs == {
         sanitize_batch_job_name(f"{dataset}_{version}_{pixel_meaning}_gradient_{i}"): (


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [x] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Vector sources with >19 layers ran into an AWS limit of 20 parents per job.

Issue Number: GTC-1075


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- When creating vector source jobs the jobs fanned-out into (a maximum of) 16 queues.
- Also, there may have been an unrelated bug creating multiple layer jobs, which was fixed by numbering the job names. Have to look more into if this is a general problem with our Batch job submissions. 
-

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
