### PR TITLE
Propagate OTF Errors

### DIFF
--- a/app/routes/datasets/queries.py
+++ b/app/routes/datasets/queries.py
@@ -442,7 +442,7 @@ async def _query_raster_lambda(
             f"Raster analysis lambda received an unexpected response: {response.text}",
         )
 
-    if response_body["status"] == "fail":
+    if response_body["status"] == "failed":
         # validation error
         raise HTTPException(422, response_body["message"])
     elif response_body["status"] == "error":

--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -67,7 +67,7 @@ data "template_file" "container_definition" {
     tile_cache_job_queue        = module.batch_job_queues.tile_cache_job_queue_arn
     pixetl_job_definition       = module.batch_job_queues.pixetl_job_definition_arn
     pixetl_job_queue            = module.batch_job_queues.pixetl_job_queue_arn
-    raster_analysis_lambda_name = "raster-analysis-tiled_raster_analysis-feature-DataEnvironment"
+    raster_analysis_lambda_name = data.terraform_remote_state.raster_analysis_lambda.outputs.raster_analysis_lambda_name
     service_url                 = local.service_url
     rw_api_url                  = var.rw_api_url
     api_token_secret_arn        = data.terraform_remote_state.core.outputs.secrets_read-gfw-api-token_arn


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [X] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [X] Check the commit's or even all commits' message styles matches our requested structure.
- [X] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
Always returns 500 error if there's an issue, with just a message to check the logs.


## What is the new behavior?

See OTF PR: https://github.com/wri/gfw-raster-analysis-lambda/pull/42

- Response format changed to JSEND format
- Propagate "fail" status from OTF as 422 validation error
- Propagate "error" status as 500 errors
- Propagate "message" field from OTF for all errors if valid JSEND format is return

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

