### PR TITLE
Allow returning multiple formats from query

### DIFF
--- a/app/models/pydantic/query.py
+++ b/app/models/pydantic/query.py
@@ -1,5 +1,7 @@
 from typing import Optional
 
+from app.models.enum.creation_options import Delimiters
+from app.models.enum.queries import QueryFormat
 from app.models.pydantic.base import StrictBaseModel
 from app.models.pydantic.geostore import Geometry
 
@@ -7,3 +9,5 @@ from app.models.pydantic.geostore import Geometry
 class QueryRequestIn(StrictBaseModel):
     geometry: Optional[Geometry]
     sql: str
+    format: QueryFormat = QueryFormat.json
+    delimter: Delimiters = Delimiters.comma

--- a/app/models/pydantic/query.py
+++ b/app/models/pydantic/query.py
@@ -1,7 +1,6 @@
 from typing import Optional
 
 from app.models.enum.creation_options import Delimiters
-from app.models.enum.queries import QueryFormat
 from app.models.pydantic.base import StrictBaseModel
 from app.models.pydantic.geostore import Geometry
 
@@ -9,5 +8,7 @@ from app.models.pydantic.geostore import Geometry
 class QueryRequestIn(StrictBaseModel):
     geometry: Optional[Geometry]
     sql: str
-    format: QueryFormat = QueryFormat.json
-    delimter: Delimiters = Delimiters.comma
+
+
+class CsvQueryRequestIn(QueryRequestIn):
+    delimiter: Delimiters = Delimiters.comma

--- a/app/responses.py
+++ b/app/responses.py
@@ -16,10 +16,12 @@ class CSVStreamingResponse(StreamingResponse):
         headers: dict = None,
         background: BackgroundTask = None,
         filename: str = "export.csv",
+        download: bool = True,
     ) -> None:
         if not headers:
             headers = dict()
-        headers["Content-Disposition"] = f"attachment; filename={filename}"
+        if download:
+            headers["Content-Disposition"] = f"attachment; filename={filename}"
 
         super().__init__(content, status_code, headers, self.media_type, background)
 

--- a/app/routes/datasets/queries.py
+++ b/app/routes/datasets/queries.py
@@ -540,7 +540,15 @@ async def _get_data_environment(grids: List[Grid] = []) -> DataEnvironment:
         if "tcd" in row.creation_options["pixel_meaning"]:
             continue
 
-        source_layer_name = f"{row.dataset}__{row.creation_options['pixel_meaning']}"
+        if {row.creation_options["pixel_meaning"]} == "is":
+            source_layer_name = (
+                f"{row.creation_options['pixel_meaning']}__{row.dataset}"
+            )
+        else:
+            source_layer_name = (
+                f"{row.dataset}__{row.creation_options['pixel_meaning']}"
+            )
+
         layers.append(_get_source_layer(row, source_layer_name))
 
         if row.creation_options["pixel_meaning"] == "date_conf":

--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -67,7 +67,7 @@ data "template_file" "container_definition" {
     tile_cache_job_queue        = module.batch_job_queues.tile_cache_job_queue_arn
     pixetl_job_definition       = module.batch_job_queues.pixetl_job_definition_arn
     pixetl_job_queue            = module.batch_job_queues.pixetl_job_queue_arn
-    raster_analysis_lambda_name = data.terraform_remote_state.raster_analysis_lambda.outputs.raster_analysis_lambda_name
+    raster_analysis_lambda_name = "raster-analysis-tiled_raster_analysis-default"
     service_url                 = local.service_url
     rw_api_url                  = var.rw_api_url
     api_token_secret_arn        = data.terraform_remote_state.core.outputs.secrets_read-gfw-api-token_arn

--- a/tests_v2/unit/routes/datasets/test_queries.py
+++ b/tests_v2/unit/routes/datasets/test_queries.py
@@ -31,3 +31,22 @@ async def test_query_dataset_with_api_key(
 
     assert response.status_code == 200
     assert response.json()["data"][0]["count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_query_dataset_csv(
+    async_client: AsyncClient, generic_vector_source_version, apikey
+):
+    dataset_name, version_name, _ = generic_vector_source_version
+    api_key, origin = apikey
+
+    headers = {"origin": origin, "x-api-key": api_key}
+
+    response = await async_client.get(
+        f"/dataset/{dataset_name}/{version_name}/query/csv?sql=select count(*) as count from data",
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    print(response.data)
+    assert response.data == "count\n1"

--- a/tests_v2/unit/routes/datasets/test_queries.py
+++ b/tests_v2/unit/routes/datasets/test_queries.py
@@ -31,22 +31,3 @@ async def test_query_dataset_with_api_key(
 
     assert response.status_code == 200
     assert response.json()["data"][0]["count"] == 1
-
-
-@pytest.mark.asyncio
-async def test_query_dataset_csv(
-    async_client: AsyncClient, generic_vector_source_version, apikey
-):
-    dataset_name, version_name, _ = generic_vector_source_version
-    api_key, origin = apikey
-
-    headers = {"origin": origin, "x-api-key": api_key}
-
-    response = await async_client.get(
-        f"/dataset/{dataset_name}/{version_name}/query/csv?sql=select count(*) as count from data",
-        headers=headers,
-    )
-
-    assert response.status_code == 200
-    print(response.data)
-    assert response.data == "count\n1"


### PR DESCRIPTION
This is a feature request from Forest Watcher, who would like to be able to also get CSV from the query endpoint without it being a file download. I made just as parity with RW API, where you can submit a parameter for the format type (default is JSON). 

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [X] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [X] Check the commit's or even all commits' message styles matches our requested structure.
- [X] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
Only way to get CSV is via download endpoint.


## What is the new behavior?

- Allow query parameter to get CSV response from query endpoint
- Some small bug fixes I found for OTF queries

## Does this introduce a breaking change?

- [ ] Yes
- [X] No


