### PR TITLE
Add timeout parameter for table source asset import

### DIFF
--- a/app/models/pydantic/creation_options.py
+++ b/app/models/pydantic/creation_options.py
@@ -5,7 +5,7 @@ from uuid import UUID
 from pydantic import Field, root_validator, validator
 from pydantic.types import PositiveInt, StrictInt
 
-from ...settings.globals import PIXETL_DEFAULT_RESAMPLING
+from ...settings.globals import DEFAULT_JOB_DURATION, PIXETL_DEFAULT_RESAMPLING
 from ..enum.assets import AssetType, is_default_asset
 from ..enum.creation_options import (
     Delimiters,
@@ -228,6 +228,7 @@ class TableAssetCreationOptions(StrictBaseModel):
         "when geographic columns are present. "
         "Disable this option by setting value to `false`",
     )
+    timeout: int = DEFAULT_JOB_DURATION
 
 
 class TableSourceCreationOptions(TableAssetCreationOptions):

--- a/app/tasks/table_source_assets.py
+++ b/app/tasks/table_source_assets.py
@@ -62,7 +62,7 @@ async def table_source_asset(
         command=command,
         environment=job_env,
         callback=callback,
-        timeout=creation_options.timeout,
+        attempt_duration_seconds=creation_options.timeout,
     )
 
     # Create partitions
@@ -117,7 +117,7 @@ async def table_source_asset(
                 environment=job_env,
                 parents=parents,
                 callback=callback,
-                timeout=creation_options.timeout,
+                attempt_duration_seconds=creation_options.timeout,
             )
         )
 
@@ -142,7 +142,7 @@ async def table_source_asset(
                 environment=job_env,
                 parents=[job.job_name for job in load_data_jobs],
                 callback=callback,
-                timeout=creation_options.timeout,
+                attempt_duration_seconds=creation_options.timeout,
             ),
         )
 
@@ -170,7 +170,7 @@ async def table_source_asset(
                 parents=parents,
                 environment=job_env,
                 callback=callback,
-                timeout=creation_options.timeout,
+                attempt_duration_seconds=creation_options.timeout,
             )
         )
 
@@ -259,7 +259,7 @@ async def append_table_source_asset(
                 command=command,
                 environment=job_env,
                 callback=callback,
-                timeout=creation_options.timeout,
+                attempt_duration_seconds=creation_options.timeout,
             )
         )
 
@@ -286,7 +286,7 @@ async def append_table_source_asset(
                 environment=job_env,
                 parents=[job.job_name for job in load_data_jobs],
                 callback=callback,
-                timeout=creation_options.timeout,
+                attempt_duration_seconds=creation_options.timeout,
             ),
         )
 
@@ -377,7 +377,7 @@ def _partition_job(
         environment=job_env,
         parents=parents,
         callback=callback,
-        timeout=timeout,
+        attempt_duration_seconds=timeout,
     )
 
 
@@ -462,7 +462,7 @@ def _create_cluster_jobs(
             environment=job_env,
             parents=parents,
             callback=callback,
-            timeout=timeout,
+            attempt_duration_seconds=timeout,
         )
         cluster_jobs.append(job)
     return cluster_jobs
@@ -504,7 +504,7 @@ def _cluster_partition_job(
         environment=job_env,
         parents=parents,
         callback=callback,
-        timeout=timeout,
+        attempt_duration_seconds=timeout,
     )
 
 

--- a/app/tasks/table_source_assets.py
+++ b/app/tasks/table_source_assets.py
@@ -62,6 +62,7 @@ async def table_source_asset(
         command=command,
         environment=job_env,
         callback=callback,
+        timeout=creation_options.timeout,
     )
 
     # Create partitions
@@ -73,6 +74,7 @@ async def table_source_asset(
             [create_table_job.job_name],
             job_env,
             callback,
+            creation_options.timeout,
         )
     else:
         partition_jobs = list()
@@ -115,6 +117,7 @@ async def table_source_asset(
                 environment=job_env,
                 parents=parents,
                 callback=callback,
+                timeout=creation_options.timeout,
             )
         )
 
@@ -139,6 +142,7 @@ async def table_source_asset(
                 environment=job_env,
                 parents=[job.job_name for job in load_data_jobs],
                 callback=callback,
+                timeout=creation_options.timeout,
             ),
         )
 
@@ -166,6 +170,7 @@ async def table_source_asset(
                 parents=parents,
                 environment=job_env,
                 callback=callback,
+                timeout=creation_options.timeout,
             )
         )
 
@@ -182,6 +187,7 @@ async def table_source_asset(
             parents,
             job_env,
             callback,
+            creation_options.timeout,
         )
     else:
         cluster_jobs = list()
@@ -253,6 +259,7 @@ async def append_table_source_asset(
                 command=command,
                 environment=job_env,
                 callback=callback,
+                timeout=creation_options.timeout,
             )
         )
 
@@ -279,6 +286,7 @@ async def append_table_source_asset(
                 environment=job_env,
                 parents=[job.job_name for job in load_data_jobs],
                 callback=callback,
+                timeout=creation_options.timeout,
             ),
         )
 
@@ -294,6 +302,7 @@ def _create_partition_jobs(
     parents,
     job_env: List[Dict[str, str]],
     callback: Callback,
+    timeout: int,
 ) -> List[PostgresqlClientJob]:
     """Create partition job depending on the partition type.
 
@@ -317,6 +326,7 @@ def _create_partition_jobs(
                 i,
                 job_env,
                 callback,
+                timeout,
             )
 
             partition_jobs.append(job)
@@ -332,6 +342,7 @@ def _create_partition_jobs(
             0,
             job_env,
             callback,
+            timeout,
         )
         partition_jobs.append(job)
 
@@ -347,6 +358,7 @@ def _partition_job(
     suffix: int,
     job_env: List[Dict[str, str]],
     callback: Callback,
+    timeout: int,
 ) -> PostgresqlClientJob:
     return PostgresqlClientJob(
         dataset=dataset,
@@ -365,6 +377,7 @@ def _partition_job(
         environment=job_env,
         parents=parents,
         callback=callback,
+        timeout=timeout,
     )
 
 
@@ -376,6 +389,7 @@ def _create_cluster_jobs(
     parents: List[str],
     job_env: List[Dict[str, str]],
     callback: Callback,
+    timeout: int,
 ) -> List[PostgresqlClientJob]:
     # Cluster tables. This is a full lock operation.
     cluster_jobs: List[PostgresqlClientJob] = list()
@@ -404,6 +418,7 @@ def _create_cluster_jobs(
                     i,
                     job_env,
                     callback,
+                    timeout,
                 )
                 cluster_jobs.append(job)
                 parents = [job.job_name]
@@ -424,6 +439,7 @@ def _create_cluster_jobs(
                 0,
                 job_env,
                 callback,
+                timeout,
             )
             cluster_jobs.append(job)
 
@@ -446,6 +462,7 @@ def _create_cluster_jobs(
             environment=job_env,
             parents=parents,
             callback=callback,
+            timeout=timeout,
         )
         cluster_jobs.append(job)
     return cluster_jobs
@@ -462,6 +479,7 @@ def _cluster_partition_job(
     index: int,
     job_env: List[Dict[str, str]],
     callback: Callback,
+    timeout: int,
 ):
     command = [
         "cluster_partitions.sh",
@@ -486,6 +504,7 @@ def _cluster_partition_job(
         environment=job_env,
         parents=parents,
         callback=callback,
+        timeout=timeout,
     )
 
 


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [X] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [X] Check the commit's or even all commits' message styles matches our requested structure.
- [X] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
Timeout for table asset import is always 2 hours for each batch job.

Issue Number: N/A


## What is the new behavior?
Add a parameter to increase the timeout for big imports.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

