### PR TITLE
Make /analysis/zonal backwards compatible with lambda query changes

### DIFF
--- a/app/routes/datasets/queries.py
+++ b/app/routes/datasets/queries.py
@@ -578,7 +578,9 @@ async def _query_raster_lambda(
 
     # response must be in JSEND format or something unexpected happened
     response_body = response.json()
-    if "status" not in response_body or "data" not in response_body:
+    if "status" not in response_body or (
+        "data" not in response_body and "message" not in response_body
+    ):
         raise HTTPException(
             500,
             f"Raster analysis lambda received an unexpected response: {response.text}",

--- a/app/routes/datasets/queries.py
+++ b/app/routes/datasets/queries.py
@@ -627,7 +627,7 @@ async def _get_data_environment(grids: List[Grid] = []) -> DataEnvironment:
         if "tcd" in row.creation_options["pixel_meaning"]:
             continue
 
-        if {row.creation_options["pixel_meaning"]} == "is":
+        if row.creation_options["pixel_meaning"] == "is":
             source_layer_name = (
                 f"{row.creation_options['pixel_meaning']}__{row.dataset}"
             )

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -39,7 +39,7 @@ services:
       - TILE_CACHE_SERVICE=tile_cache_service
       - PIXETL_JOB_QUEUE=pixetl_jq
       - API_URL=http://app_dev:80
-      - RASTER_ANALYSIS_LAMBDA_NAME=raster-analysis-tiled_raster_analysis-feature-DataEnvironment
+      - RASTER_ANALYSIS_LAMBDA_NAME=raster-analysis-tiled_raster_analysis-default
       - RW_API_URL=https://staging-api.resourcewatch.org
     ports:
       - 8008:80


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [X] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [X] Check the commit's or even all commits' message styles matches our requested structure.
- [X] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
/analysis/zonal is not backwards compatible because of certain pieces of the query interface were deprecated. This will break OTF in production.


## What is the new behavior?

- alert__count is deprecated, so maybe alert__count to count(*)
- umd_glad_alerts is now umd_glad_landsat_alerts, so replace the name
- isoweek is not a selector function on dates rather than a layer data type, so umd_glad_alerts__isoweek should be isoweek(umd_glad_alerts__date)

## Does this introduce a breaking change?

- [ ] Yes
- [X] No
