### PR TITLE
Temporarily Disable API Key Checks

### DIFF
--- a/app/routes/analysis/analysis.py
+++ b/app/routes/analysis/analysis.py
@@ -48,7 +48,7 @@ async def zonal_statistics_get(
         description="Must be either year or YYYY-MM-DD date format.",
         regex=DATE_REGEX,
     ),
-    api_key: APIKey = Depends(get_api_key),
+    # api_key: APIKey = Depends(get_api_key),
 ):
     """Calculate zonal statistics on any registered raster layers in a
     geostore."""

--- a/app/routes/datasets/queries.py
+++ b/app/routes/datasets/queries.py
@@ -18,7 +18,8 @@ from fastapi import Request as FastApiRequest
 from fastapi import Response as FastApiResponse
 from fastapi.encoders import jsonable_encoder
 from fastapi.logger import logger
-from fastapi.openapi.models import APIKey
+
+# from fastapi.openapi.models import APIKey
 from fastapi.responses import RedirectResponse
 from pglast import printers  # noqa
 from pglast import Node, parse_sql
@@ -27,7 +28,8 @@ from pglast.printer import RawStream
 from sqlalchemy.sql import and_
 
 from ...application import db
-from ...authentication.api_keys import get_api_key
+
+# from ...authentication.api_keys import get_api_key
 from ...crud import assets
 from ...models.enum.assets import AssetType
 from ...models.enum.creation_options import Delimiters
@@ -122,7 +124,7 @@ async def query_dataset_json(
     geostore_origin: GeostoreOrigin = Query(
         GeostoreOrigin.gfw, description="Origin service of geostore ID."
     ),
-    api_key: APIKey = Depends(get_api_key),
+    # api_key: APIKey = Depends(get_api_key),
 ):
     """Execute a READ-ONLY SQL query on the given dataset version (if
     implemented) and return response in JSON format.
@@ -167,7 +169,7 @@ async def query_dataset_csv(
     delimiter: Delimiters = Query(
         Delimiters.comma, description="Delimiter to use for CSV file."
     ),
-    api_key: APIKey = Depends(get_api_key),
+    # api_key: APIKey = Depends(get_api_key),
 ):
     """Execute a READ-ONLY SQL query on the given dataset version (if
     implemented) and return response in CSV format.
@@ -225,7 +227,7 @@ async def query_dataset_json_post(
     *,
     dataset_version: Tuple[str, str] = Depends(dataset_version_dependency),
     request: QueryRequestIn,
-    api_key: APIKey = Depends(get_api_key),
+    # api_key: APIKey = Depends(get_api_key),
 ):
     """Execute a READ-ONLY SQL query on the given dataset version (if
     implemented)."""
@@ -247,7 +249,7 @@ async def query_dataset_csv_post(
     *,
     dataset_version: Tuple[str, str] = Depends(dataset_version_dependency),
     request: CsvQueryRequestIn,
-    api_key: APIKey = Depends(get_api_key),
+    # api_key: APIKey = Depends(get_api_key),
 ):
     """Execute a READ-ONLY SQL query on the given dataset version (if
     implemented)."""

--- a/tests_v2/unit/routes/analysis/test_analysis.py
+++ b/tests_v2/unit/routes/analysis/test_analysis.py
@@ -2,6 +2,7 @@ import pytest
 from httpx import AsyncClient
 
 
+@pytest.mark.skip("Temporarily skip until we require API keys")
 @pytest.mark.asyncio
 async def test_analysis_without_api_key(geostore, async_client: AsyncClient):
 

--- a/tests_v2/unit/routes/datasets/test_queries.py
+++ b/tests_v2/unit/routes/datasets/test_queries.py
@@ -2,6 +2,7 @@ import pytest
 from httpx import AsyncClient
 
 
+@pytest.mark.skip("Temporarily skip until we require API keys")
 @pytest.mark.asyncio
 async def test_query_dataset_without_api_key(
     generic_vector_source_version, async_client: AsyncClient


### PR DESCRIPTION
Temporarily disable API key checks so we can unblock pushing changes to production while we wait for users to starting using API keys.