### PR TITLE
Bump pixetl to fix boto3 client sharing; Fix specifying S3 prefixes with lots of files in src_uri

### DIFF
--- a/batch/pixetl.dockerfile
+++ b/batch/pixetl.dockerfile
@@ -1,4 +1,4 @@
-FROM globalforestwatch/pixetl:v1.5.5
+FROM globalforestwatch/pixetl:v1.5.6
 
 # Copy scripts
 COPY ./batch/scripts/ /opt/scripts/

--- a/batch/python/raster_tile_cache.py
+++ b/batch/python/raster_tile_cache.py
@@ -108,7 +108,7 @@ def create_tiles(args: Tuple[Tuple[str, str], str, str, str, str, int, bool, int
         s3_client.download_file(tile[0], tile[1], tile_name)
 
         cmd = [
-            "16bpp_gdal2tiles.py",
+            "gdal2tiles.py",
             f"--zoom={zoom_level}",
             "--s_srs",
             "EPSG:3857",

--- a/batch/python/raster_tile_cache.py
+++ b/batch/python/raster_tile_cache.py
@@ -66,21 +66,25 @@ def run_gdal_subcommand(cmd: List[str], env: Optional[Dict] = None) -> Tuple[str
 
 
 def get_input_tiles(prefix: str) -> List[Tuple[str, str]]:
+    bucket, prefix = get_s3_path_parts(prefix)
+
+    tiles: List[Tuple[str, str]] = list()
+
     s3_client = get_s3_client()
 
-    bucket, prefix = get_s3_path_parts(prefix)
-    resp = s3_client.list_objects_v2(Bucket=bucket, Prefix=prefix)
+    paginator = s3_client.get_paginator("list_objects_v2")
+    for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+        try:
+            contents = page["Contents"]
+        except KeyError:
+            break
 
-    if resp["KeyCount"] == 0:
-        raise Exception(f"No files found in tile set prefix {prefix}")
-
-    tiles: List[Tuple[str, str]] = []
-    for obj in resp["Contents"]:
-        key = str(obj["Key"])
-        if key.endswith(".tif"):
-            LOGGER.info(f"Found remote TIFF: {key}")
-            tile = (bucket, key)
-            tiles.append(tile)
+        for obj in contents:
+            key = str(obj["Key"])
+            if key.endswith(".tif"):
+                LOGGER.info(f"Found remote TIFF: {key}")
+                tile = (bucket, key)
+                tiles.append(tile)
 
     return tiles
 
@@ -104,7 +108,7 @@ def create_tiles(args: Tuple[Tuple[str, str], str, str, str, str, int, bool, int
         s3_client.download_file(tile[0], tile[1], tile_name)
 
         cmd = [
-            "gdal2tiles.py",
+            "16bpp_gdal2tiles.py",
             f"--zoom={zoom_level}",
             "--s_srs",
             "EPSG:3857",
@@ -138,11 +142,11 @@ def raster_tile_cache(
     version: str = Option(..., help="Version number."),
     zoom_level: int = Option(..., help="Zoom level."),
     implementation: str = Option(..., help="Implementation name/ pixel meaning."),
-    target_bucket: str = Option(..., help="Target bucket,"),
+    target_bucket: str = Option(..., help="Target bucket."),
     skip_empty_tiles: bool = Option(
         False, "--skip_empty_tiles", help="Do not write empty tiles to tile cache."
     ),
-    tile_set_prefix: str = Argument(..., help="Tile prefix,"),
+    tile_set_prefix: str = Argument(..., help="Tile prefix."),
 ):
     LOGGER.info(f"Raster tile set asset prefix: {tile_set_prefix}")
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [x] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- Imports sometimes encounters weird errors downloading from S3 due to pixetl processes sharing boto3 clients
- raster tile cache batch job could theoretically choke on S3 prefixes with lots of files due to lack of pagination (unobserved)

Issue Number: GTC-1312


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
- Pixetl version is bumped to version fixing client sharing
- Use of list_objects_v2 modified to use pagination
-

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
