### PR TITLE
Catch OOM errors that somehow don't exit with 137

### DIFF
--- a/app/tasks/batch.py
+++ b/app/tasks/batch.py
@@ -12,6 +12,7 @@ from ..models.pydantic.jobs import Job
 from ..utils.aws import get_batch_client
 
 BATCH_DEPENDENCY_LIMIT = 14
+OOM_ERROR = "OutOfMemoryError: Container killed due to memory usage"
 
 
 async def execute(
@@ -139,6 +140,8 @@ def submit_batch_job(
                 # This is likely due to OOM, and report_status.sh will
                 # halve NUM_PROCESSES for retry
                 {"onExitCode": "137", "action": "RETRY"},
+                # Catch OOM situations which somehow didn't exit with 137
+                {"onReason": OOM_ERROR, "action": "RETRY"},
                 # Otherwise exit
                 {"onReason": "*", "action": "EXIT"},
             ],

--- a/batch/python/adjust_num_processes.py
+++ b/batch/python/adjust_num_processes.py
@@ -4,6 +4,8 @@ import os
 
 import boto3
 
+OOM_ERROR = "OutOfMemoryError: Container killed due to memory usage"
+
 
 def calc_num_processes(job_id: str, original_num_proc, batch_client):
     jobs_desc = batch_client.describe_jobs(jobs=[job_id])
@@ -12,7 +14,10 @@ def calc_num_processes(job_id: str, original_num_proc, batch_client):
 
     # For each previous attempt resulting in OOM, divide NUM_PROCESSES by 2
     for attempt in jobs_desc["jobs"][0]["attempts"]:
-        if attempt["container"]["exitCode"] == 137:
+        if (
+            attempt["container"].get("exitCode") == 137
+            or attempt["container"].get("reason") == OOM_ERROR
+        ):
             new_num_proc = max(1, int(new_num_proc / 2))
 
     return new_num_proc


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [x] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Justin observed pixetl exiting with an exit code of 1 despite subprocesses being killed due to running out of memory. The container "reason" was set appropriately, though.

Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

-Check for the OOM message in reason in addition to checking the exit code in case we have missed some OOM case

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
