### PR TITLE
Allow batch options for tile assets besides the default

### DIFF
--- a/app/models/pydantic/creation_options.py
+++ b/app/models/pydantic/creation_options.py
@@ -113,6 +113,8 @@ class RasterTileSetAssetCreationOptions(StrictBaseModel):
     process_locally: bool = True
     auxiliary_assets: Optional[List[UUID]] = None
     photometric: Optional[PhotometricType] = None
+    num_processes: Optional[StrictInt] = None
+    timeout_sec: Optional[StrictInt] = None
 
     @validator("no_data")
     def validate_no_data(cls, v, values, **kwargs):
@@ -143,8 +145,6 @@ class PixETLCreationOptions(RasterTileSetAssetCreationOptions):
         "tiles.geojson file on S3 or a folder (prefix) on S3 or GCS. "
         "Features in tiles.geojson must have path starting with either /vsis3/ or /vsigs/",
     )
-    num_processes: Optional[StrictInt] = None
-    timeout_sec: Optional[StrictInt] = None
 
     @validator("source_uri")
     def validate_source_uri(cls, v, values, **kwargs):


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [X] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [X] Check the commit's or even all commits' message styles matches our requested structure.
- [X] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
Including batch options like num_processes and timeout is only available for the default asset. However, sometimes we might need it on other assets (like resampling to 10/100000). 


## What is the new behavior?

- Batch options are now allowed on any asset.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

