### PR TITLE
Various integrated alerts changes

### DIFF
--- a/app/routes/datasets/queries.py
+++ b/app/routes/datasets/queries.py
@@ -686,14 +686,16 @@ def _get_source_layer(row, source_layer_name: str) -> SourceLayer:
     if source_layer_name == "umd_glad_landsat_alerts__date_conf":
         source_uri = "s3://gfw2-data/forest_change/umd_landsat_alerts/prod/analysis/{tile_id}.tif"
         tile_scheme = "nwse"
+        grid = Grid.ten_by_forty_thousand
     else:
         source_uri = row.asset_uri
         tile_scheme = "nw"
+        grid = row.creation_options["grid"]
 
     return SourceLayer(
         source_uri=source_uri,
         tile_scheme=tile_scheme,
-        grid=row.creation_options["grid"],
+        grid=grid,
         name=source_layer_name,
         raster_table=row.metadata.get("raster_table", None),
     )
@@ -708,10 +710,12 @@ def _get_date_conf_derived_layers(row, source_layer_name) -> List[DerivedLayer]:
     decode_expression = "(A + 16435).astype('datetime64[D]').astype(str)"
     encode_expression = "(datetime64(A) - 16435).astype(uint16)"
     conf_encoding = RasterTable(
+        default_meaning="not_detected",
         rows=[
-            RasterTableRow(value=2, meaning=""),
+            RasterTableRow(value=2, meaning="nominal"),
             RasterTableRow(value=3, meaning="high"),
-        ]
+            RasterTableRow(value=4, meaning="highest"),
+        ],
     )
 
     return [

--- a/app/tasks/raster_tile_cache_assets/utils.py
+++ b/app/tasks/raster_tile_cache_assets/utils.py
@@ -266,6 +266,8 @@ def scale_batch_job(job: Job, zoom_level: int):
     job.memory = (MAX_MEM / MAX_CORES) * job.vcpus
     job.num_processes = max(1, int(job.vcpus / cpu_proc_ratio))
 
-    job.attempt_duration_seconds = int(DEFAULT_JOB_DURATION * (zoom_level / 3))
+    job.attempt_duration_seconds = max(
+        DEFAULT_JOB_DURATION, int(DEFAULT_JOB_DURATION * (zoom_level / 3))
+    )
 
     return job

--- a/app/tasks/raster_tile_cache_assets/utils.py
+++ b/app/tasks/raster_tile_cache_assets/utils.py
@@ -13,7 +13,12 @@ from app.models.pydantic.creation_options import RasterTileSetSourceCreationOpti
 from app.models.pydantic.jobs import GDAL2TilesJob, Job
 from app.models.pydantic.metadata import RasterTileSetMetadata
 from app.models.pydantic.statistics import RasterStats
-from app.settings.globals import MAX_CORES, MAX_MEM, TILE_CACHE_BUCKET
+from app.settings.globals import (
+    DEFAULT_JOB_DURATION,
+    MAX_CORES,
+    MAX_MEM,
+    TILE_CACHE_BUCKET,
+)
 from app.tasks import Callback, callback_constructor
 from app.tasks.raster_tile_set_assets.utils import JOB_ENV, create_pixetl_job
 from app.tasks.utils import sanitize_batch_job_name
@@ -260,5 +265,7 @@ def scale_batch_job(job: Job, zoom_level: int):
     job.vcpus = min(job.vcpus, math.ceil(2 ** (zoom_level - 4)))
     job.memory = (MAX_MEM / MAX_CORES) * job.vcpus
     job.num_processes = max(1, int(job.vcpus / cpu_proc_ratio))
+
+    job.attempt_duration_seconds = int(DEFAULT_JOB_DURATION * (zoom_level / 3))
 
     return job


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [X] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [X] Check the commit's or even all commits' message styles matches our requested structure.
- [X] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

Please check the type of change your PR introduces:
- [X] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
-Confidence levels for date_conf OTF are only high or empty
-If GLAD has an asset defined, it'll use that grid instead of the grid for the legacy GLAD
-Timeout for batch jobs for zoom level assets are always the default timeout


## What is the new behavior?

- Confidence levels for date conf are now 2-"nominal", 3-"high", 4-"highest", default-"not_detected"
- Legacy GLAD asset will always use 10/40000 grid
- Timeout for batch jobs is extended based on zoom level, since high levels can take a long time to process

## Does this introduce a breaking change?

- [ ] Yes
- [X] No


