### PR TITLE
Only allow assets in a single grid to be analyzed in an OTF query

### DIFF
--- a/app/routes/datasets/queries.py
+++ b/app/routes/datasets/queries.py
@@ -573,20 +573,20 @@ async def _query_raster(
         if default_type == "is"
         else f"{dataset}__{default_type}"
     )
+    grid = asset.creation_options["grid"]
 
     sql = re.sub("from \w+", f"from {default_layer}", sql, flags=re.IGNORECASE)
-    return await _query_raster_lambda(geostore.geojson, sql, format, delimiter)
+    return await _query_raster_lambda(geostore.geojson, sql, grid, format, delimiter)
 
 
 async def _query_raster_lambda(
     geometry: Geometry,
     sql: str,
+    grid: Grid = Grid.ten_by_forty_thousand,
     format: QueryFormat = QueryFormat.json,
     delimiter: Delimiters = Delimiters.comma,
 ) -> Dict[str, Any]:
-    data_environment = await _get_data_environment(
-        grids=[Grid.ten_by_forty_thousand, Grid.ten_by_one_hundred_thousand]
-    )
+    data_environment = await _get_data_environment(grid)
     payload = {
         "geometry": jsonable_encoder(geometry),
         "query": sql,
@@ -628,7 +628,7 @@ async def _query_raster_lambda(
     return response_body
 
 
-async def _get_data_environment(grids: List[Grid] = []) -> DataEnvironment:
+async def _get_data_environment(grid: Grid) -> DataEnvironment:
     # get all Raster tile set assets
     latest_tile_sets = await (
         AssetORM.join(VersionORM)
@@ -653,12 +653,16 @@ async def _get_data_environment(grids: List[Grid] = []) -> DataEnvironment:
     # create layers
     layers: List[Layer] = []
     for row in latest_tile_sets:
-        if grids and row.creation_options["grid"] not in grids:
+        if row.creation_options["grid"] != grid:
             # skip if not on the right grid
             continue
 
         # TODO skip intermediate raster for tile cache until field is in metadata
         if "tcd" in row.creation_options["pixel_meaning"]:
+            continue
+
+        # only include single band rasters
+        if row.creation_options.get("band_count", 1) > 1:
             continue
 
         if row.creation_options["pixel_meaning"] == "is":
@@ -670,7 +674,7 @@ async def _get_data_environment(grids: List[Grid] = []) -> DataEnvironment:
                 f"{row.dataset}__{row.creation_options['pixel_meaning']}"
             )
 
-        layers.append(_get_source_layer(row, source_layer_name))
+        layers.append(_get_source_layer(row, grid, source_layer_name))
 
         if row.creation_options["pixel_meaning"] == "date_conf":
             layers += _get_date_conf_derived_layers(row, source_layer_name)
@@ -681,9 +685,12 @@ async def _get_data_environment(grids: List[Grid] = []) -> DataEnvironment:
     return DataEnvironment(layers=layers)
 
 
-def _get_source_layer(row, source_layer_name: str) -> SourceLayer:
+def _get_source_layer(row, grid, source_layer_name: str) -> SourceLayer:
     # TODO we need to start uploading GLAD directly to the data API
-    if source_layer_name == "umd_glad_landsat_alerts__date_conf":
+    if (
+        source_layer_name == "umd_glad_landsat_alerts__date_conf"
+        and grid == Grid.ten_by_forty_thousand
+    ):
         source_uri = "s3://gfw2-data/forest_change/umd_landsat_alerts/prod/analysis/{tile_id}.tif"
         tile_scheme = "nwse"
         grid = Grid.ten_by_forty_thousand

--- a/app/routes/datasets/versions.py
+++ b/app/routes/datasets/versions.py
@@ -20,7 +20,6 @@ from ...authentication.token import is_admin
 from ...crud import assets, versions
 from ...errors import RecordAlreadyExistsError, RecordNotFoundError
 from ...models.enum.assets import AssetStatus, AssetType
-from ...models.enum.pixetl import Grid
 from ...models.orm.assets import Asset as ORMAsset
 from ...models.orm.versions import Version as ORMVersion
 from ...models.pydantic.change_log import ChangeLog, ChangeLogResponse
@@ -322,11 +321,9 @@ async def get_fields(dv: Tuple[str, str] = Depends(dataset_version_dependency)):
 
 async def _get_raster_fields(asset: ORMAsset) -> List[RasterFieldMetadata]:
     fields: List[RasterFieldMetadata] = []
-    grids = [Grid.ten_by_forty_thousand]
-    if asset.creation_options["grid"] == Grid.ten_by_one_hundred_thousand:
-        grids.append(Grid.ten_by_one_hundred_thousand)
+    grid = asset.creation_options["grid"]
 
-    raster_data_environment = await _get_data_environment(grids=grids)
+    raster_data_environment = await _get_data_environment(grid)
 
     logger.debug(f"Processing data environment f{raster_data_environment}")
     for layer in raster_data_environment.layers:


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [X] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [X] Check the commit's or even all commits' message styles matches our requested structure.
- [X] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
An OTF query can include raster assets in multiple grids, as long as it's upsampling. However, it turns out the dynamic resampling was off from the static resampling in pixetl. Moreover, now that many of our assets are resampled to multiple grids, a lot of the fields are being listed multiple times for each resolution.


## What is the new behavior?

- OTF will only analyze rasters strictly in the same grid, and this grid will be determined by the primary asset being analyzed
- The fields endpoint for rasters will now only list rasters available in the grid of the primary asset

## Does this introduce a breaking change?

- [X] Yes
- [ ] No

This potentially makes it so contextual layers not resampled to 10/100000 are no longer available for OTF. But no one should be using those yet, and anyway we should be resampling them if we need them. @manukala6 could you confirm if you think this might be an issue?
