### PR TITLE
Use correct default layer for date_conf rasters

### DIFF
--- a/app/routes/datasets/queries.py
+++ b/app/routes/datasets/queries.py
@@ -567,12 +567,7 @@ async def _query_raster(
         )
 
     # use default data type to get default raster layer for dataset
-    default_type = asset.creation_options["pixel_meaning"]
-    default_layer = (
-        f"{default_type}__{dataset}"
-        if default_type == "is"
-        else f"{dataset}__{default_type}"
-    )
+    default_layer = _get_default_layer(dataset, asset.creation_options["pixel_meaning"])
     grid = asset.creation_options["grid"]
 
     sql = re.sub("from \w+", f"from {default_layer}", sql, flags=re.IGNORECASE)
@@ -626,6 +621,17 @@ async def _query_raster_lambda(
         raise HTTPException(500, response_body["message"])
 
     return response_body
+
+
+def _get_default_layer(dataset, pixel_meaning):
+    default_type = pixel_meaning
+    if default_type == "is":
+        return f"{default_type}__{dataset}"
+    elif "date_conf" in default_type:
+        # use date layer for date_conf encoding
+        return f"{dataset}__date"
+    else:
+        return f"{dataset}__{default_type}"
 
 
 async def _get_data_environment(grid: Grid) -> DataEnvironment:


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [X] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [X] Check the commit's or even all commits' message styles matches our requested structure.
- [X] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type


Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
OTF always sets the default asset for a query as the source in the "from" statement. This applies a mask for that dataset on the query. This conflicts for date_conf layers, where we actually want to mask with decoded layer.

## What is the new behavior?

- For date_conf layers, mask with the decoded date layer


## Does this introduce a breaking change?

- [ ] Yes
- [X] No

