### PR TITLE
Include trailing slash when deleting S3 assets in folder

### DIFF
--- a/app/tasks/delete_assets.py
+++ b/app/tasks/delete_assets.py
@@ -53,7 +53,7 @@ async def delete_raster_tileset_assets(
     value: str,
 ) -> None:
     delete_s3_objects(
-        DATA_LAKE_BUCKET, f"{dataset}/{version}/raster/{srid}/{grid}/{value}"
+        DATA_LAKE_BUCKET, f"{dataset}/{version}/raster/{srid}/{grid}/{value}/"
     )
 
 


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [X] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [X] Check the commit's or even all commits' message styles matches our requested structure.
- [X] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
If you delete a raster asset whose pixel meaning has the same suffix as another raster asset (e.g. "date" and "date_conf"), you'll actually delete both raster assets S3 files, because we're deleting on the prefix version/raster/.../date* instead of version/raster/.../date/



## What is the new behavior?
Add a trailing slash to make sure it only deletes a folder name with the prefix, not similarly named folders.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

