### PR TITLE
Disable caching for API gateway lambda authorizer

### DIFF
--- a/terraform/api_gateway.tf
+++ b/terraform/api_gateway.tf
@@ -192,6 +192,7 @@ resource "aws_api_gateway_authorizer" "api_key" {
   type                   = "REQUEST"
   authorizer_uri         = aws_lambda_function.authorizer.invoke_arn
   authorizer_credentials = aws_iam_role.invocation_role.arn
+  authorizer_result_ttl_in_seconds = 0
 
   # making sure terraform doesn't require default authorization
   # header (https://github.com/hashicorp/terraform-provider-aws/issues/5845)


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [X] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [X] Check the commit's or even all commits' message styles matches our requested structure.
- [X] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
Lambda authorizer uses default caching time of 300 with no identity source to use as a cache key.


## What is the new behavior?
Disable caching for lambda authorizer.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

