### PR TITLE
Increase aurora writer size

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -138,6 +138,7 @@ module "batch_aurora_writer" {
   suffix                   = local.name_suffix
   tags                     = local.batch_tags
   use_ephemeral_storage    = false
+  ebs_volume_size          = 60
   compute_environment_name = "aurora_sql_writer"
 }
 


### PR DESCRIPTION
Large index jobs on the aurora writer use a decent of amount of space on disk for temporary postgres-related files. After the AMI size change, some jobs have started failing because the disk is running out space and postgres can't write to it. So just increasing size for the aurora writer.

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [X] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [X] Check the commit's or even all commits' message styles matches our requested structure.
- [X] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
EBS volume size is default 30 GB. 

## What is the new behavior?
Increase EBS volume size to 60 GB.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

