### PR TITLE
Make sure GLAD is usable in deprecated analysis

### DIFF
--- a/app/routes/datasets/queries.py
+++ b/app/routes/datasets/queries.py
@@ -668,12 +668,11 @@ async def _get_data_environment(
     layers: List[Layer] = []
     for row in latest_tile_sets:
         # TODO remove GLAD exception after migration
-        if default_layer == "umd_glad_landsat_alerts__date":
-            if (
-                row.dataset != "umd_glad_landsat_alerts"
-                and row.creation_options["grid"] != Grid.ten_by_forty_thousand
-            ):
-                continue
+        if (
+            row.dataset == "umd_glad_landsat_alerts"
+            and row.creation_options["grid"] != Grid.ten_by_forty_thousand
+        ):
+            continue
         elif row.creation_options["grid"] != grid:
             # skip if not on the right grid
             continue

--- a/app/routes/datasets/queries.py
+++ b/app/routes/datasets/queries.py
@@ -571,12 +571,14 @@ async def _query_raster(
 
     # use default data type to get default raster layer for dataset
     default_layer = _get_default_layer(dataset, asset.creation_options["pixel_meaning"])
-    grid = asset.creation_options["grid"]
+    grid = (
+        asset.creation_options["grid"]
+        if asset.dataset != "umd_glad_landsat_alerts"
+        else Grid.ten_by_forty_thousand
+    )
 
     sql = re.sub("from \w+", f"from {default_layer}", sql, flags=re.IGNORECASE)
-    return await _query_raster_lambda(
-        geostore.geojson, sql, grid, format, delimiter, default_layer
-    )
+    return await _query_raster_lambda(geostore.geojson, sql, grid, format, delimiter)
 
 
 async def _query_raster_lambda(
@@ -585,9 +587,8 @@ async def _query_raster_lambda(
     grid: Grid = Grid.ten_by_forty_thousand,
     format: QueryFormat = QueryFormat.json,
     delimiter: Delimiters = Delimiters.comma,
-    default_layer: Optional[str] = None,
 ) -> Dict[str, Any]:
-    data_environment = await _get_data_environment(grid, default_layer)
+    data_environment = await _get_data_environment(grid)
     payload = {
         "geometry": jsonable_encoder(geometry),
         "query": sql,
@@ -640,9 +641,7 @@ def _get_default_layer(dataset, pixel_meaning):
         return f"{dataset}__{default_type}"
 
 
-async def _get_data_environment(
-    grid: Grid, default_layer: Optional[str] = None
-) -> DataEnvironment:
+async def _get_data_environment(grid: Grid) -> DataEnvironment:
     # get all Raster tile set assets
     latest_tile_sets = await (
         AssetORM.join(VersionORM)
@@ -668,12 +667,12 @@ async def _get_data_environment(
     layers: List[Layer] = []
     for row in latest_tile_sets:
         # TODO remove GLAD exception after migration
-        if (
-            row.dataset == "umd_glad_landsat_alerts"
-            and row.creation_options["grid"] != Grid.ten_by_forty_thousand
-        ):
-            continue
-        elif row.creation_options["grid"] != grid:
+        row_grid = (
+            row.creation_options["grid"]
+            if row.dataset != "umd_glad_landsat_alerts"
+            else Grid.ten_by_forty_thousand
+        )
+        if row_grid != grid:
             # skip if not on the right grid
             continue
 
@@ -694,7 +693,7 @@ async def _get_data_environment(
                 f"{row.dataset}__{row.creation_options['pixel_meaning']}"
             )
 
-        layers.append(_get_source_layer(row, grid, source_layer_name, default_layer))
+        layers.append(_get_source_layer(row, source_layer_name))
 
         if row.creation_options["pixel_meaning"] == "date_conf":
             layers += _get_date_conf_derived_layers(row, source_layer_name)
@@ -705,14 +704,9 @@ async def _get_data_environment(
     return DataEnvironment(layers=layers)
 
 
-def _get_source_layer(
-    row, grid, source_layer_name: str, default_layer: Optional[str] = None
-) -> SourceLayer:
+def _get_source_layer(row, source_layer_name: str) -> SourceLayer:
     # TODO we need to start uploading GLAD directly to the data API ASAP @_@
-    if source_layer_name == "umd_glad_landsat_alerts__date_conf" and (
-        default_layer == "umd_glad_landsat_alerts__date"
-        or grid == Grid.ten_by_forty_thousand
-    ):
+    if source_layer_name == "umd_glad_landsat_alerts__date_conf":
         source_uri = "s3://gfw2-data/forest_change/umd_landsat_alerts/prod/analysis/{tile_id}.tif"
         tile_scheme = "nwse"
         grid = Grid.ten_by_forty_thousand


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [X] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [X] Check the commit's or even all commits' message styles matches our requested structure.
- [X] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
GLAD alerts can only be accessed for OTF directly at /dataset/umd_glad_landsat_alerts

Issue Number: GTC-1635


## What is the new behavior?
Make GLAD alerts available for all of OTF, including deprecated /analysis/zonal endpoint for backwards compatibiliy.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

