### PR TITLE
Screw it, let's just remove all the GLAD exceptions

### DIFF
--- a/app/routes/datasets/versions.py
+++ b/app/routes/datasets/versions.py
@@ -21,7 +21,6 @@ from ...authentication.token import is_admin
 from ...crud import assets, versions
 from ...errors import RecordAlreadyExistsError, RecordNotFoundError
 from ...models.enum.assets import AssetStatus, AssetType
-from ...models.enum.pixetl import Grid
 from ...models.orm.assets import Asset as ORMAsset
 from ...models.orm.versions import Version as ORMVersion
 from ...models.pydantic.change_log import ChangeLog, ChangeLogResponse
@@ -339,11 +338,7 @@ async def get_fields(dv: Tuple[str, str] = Depends(dataset_version_dependency)):
 
 async def _get_raster_fields(asset: ORMAsset) -> List[RasterFieldMetadata]:
     fields: List[RasterFieldMetadata] = []
-    grid = (
-        asset.creation_options["grid"]
-        if asset.dataset != "umd_glad_landsat_alerts"
-        else Grid.ten_by_forty_thousand
-    )
+    grid = asset.creation_options["grid"]
 
     raster_data_environment = await _get_data_environment(grid)
 


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [X] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [X] Check the commit's or even all commits' message styles matches our requested structure.
- [X] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

Please check the type of change your PR introduces:
- [X] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
For figuring out raster datasets available for OTF, we currently have multiple exceptions for GLAD pointing to the legacy bucket. This consistently is causing bugs with how we configure GLAD in the API. In the latest bug, the resampled GLAD raster isn't available for OTF with other 10/100000 resolution rasters.

Issue Number: GTC-1667


## What is the new behavior?
Since GLAD is not going to update until we finish migrating it to the API, I just manually migrated the 10/40000 rasters from the legacy bucket to the data API. Then, I created a 10/100000 resampled asset. This is how we plan to do it post-migration.

By doing this, there's no need for exceptions for GLAD in the code, everything should work by design. So just removing all the GLAD exceptions.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

