### PR TITLE
Use correct default layer for area density layers

### DIFF
--- a/app/routes/datasets/queries.py
+++ b/app/routes/datasets/queries.py
@@ -633,6 +633,11 @@ def _get_default_layer(dataset, pixel_meaning):
     elif "date_conf" in default_type:
         # use date layer for date_conf encoding
         return f"{dataset}__date"
+    elif default_type.endswith("ha-1"):
+        # remove ha-1 suffix for area density rasters
+        # OTF will multiply by pixel area to get base type
+        # and table names can't include '-1'
+        return f"{dataset}__{default_type[:-5]}"
     else:
         return f"{dataset}__{default_type}"
 


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [X] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [X] Check the commit's or even all commits' message styles matches our requested structure.
- [X] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
When you do an OTF query, the API will automatically set the default asset of the dataset you're querying as the table in the "FROM" part of the SQL statement. The _get_default_layer function get the OTF field name for the default asset by combining the dataset name with the pixel meaning of the default asset. So an OTF query like /dataset/umd_tree_cover_loss/latest/query?sql=SELECT sum(area__ha) FROM data gets transformed into SELECT sum(area__ha) FROM umd_tree_cover_loss__year when sent to OTF (and OTF will mask to that layer).

For some special pixel meanings, like date_conf, the API creates derivative assets (e.g. __date or __conf), and uses those here. For pixel meanings that end in ha-1 (per hectare), the API creates a derivative asset of the gross amount, so that removes the ha-1 (and OTF will multiply each pixel by the hectare area). But currently it still uses the field with ha-1 in the FROM statement, and the '-1' in the FROM statement is invalid SQL (table names can't '-') which throws a parse error. 

## What is the new behavior?
The fix is just to remove the 'ha-1' and use the gross layer as a mask, which should be the same.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

