### PR TITLE
Use read only RDS endpoint when creating raster assets

### DIFF
--- a/app/tasks/raster_tile_set_assets/utils.py
+++ b/app/tasks/raster_tile_set_assets/utils.py
@@ -17,10 +17,10 @@ from app.settings.globals import (
     MAX_MEM,
     S3_ENTRYPOINT_URL,
 )
-from app.tasks import Callback, writer_secrets
+from app.tasks import Callback, reader_secrets
 from app.utils.path import get_asset_uri, split_s3_path, tile_uri_to_tiles_geojson
 
-JOB_ENV = writer_secrets + [
+JOB_ENV = reader_secrets + [
     {"name": "AWS_REGION", "value": AWS_REGION},
     {"name": "ENV", "value": ENV},
 ]


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [X] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [X] Check the commit's or even all commits' message styles matches our requested structure.
- [X] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
For raster asset jobs, we send the writer DB endpoint/credentials to PixETL. For creating rasters, PixETL will only ever read from the DB, not write to it. By using the writer endpoint, queries can only run on the 1 writer instance in RDS. This was causing issues for rasterization, which will run many parallel queries on the DB, so was overloading this one instance.


## What is the new behavior?
By using the read only RDS endpoint, the queries can be load balanced to the writer instance or any read replica. It will also trigger autoscaling of new read replicas if the queries are hitting CPU limits.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No
