### PR TITLE
chore(test environment): GTC-1893 Allow user to explicitly set motoserver port

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ High-performance Async REST API, in Python. FastAPI + GINO + Uvicorn (powered by
 ### Developing
 * Generate a DB Migration: `./scripts/migrate` (note `app/settings/prestart.sh` will run migrations automatically when running `/scripts/develop`)
 * Run tests: `./scripts/test`
+  * `--no_build` - don't rebuild the containers
+  * `--moto-port=<port_number>` - explicitly sets the motoserver port (default `5000`)
 * Run specific tests: `./scripts/test tasks/test_vector_source_assets.py::test_vector_source_asset`
 * Debug memory usage of Batch jobs with memory_profiler:
     1. Install memory_profiler in the job's Dockerfile

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -87,7 +87,7 @@ services:
     container_name: motoserver-s3
     image: motoserver/moto:2.0.10
     ports:
-      - 5000:5000
+      - "${MOTO_PORT-5000}:5000"
     entrypoint: moto_server s3 -H 0.0.0.0
     restart: on-failure
 

--- a/scripts/test
+++ b/scripts/test
@@ -24,6 +24,12 @@ do
       SLOW=--with-slow-tests
       shift # past argument
       ;;
+      --moto-port=*)
+      # prevent port binding issues by explicitly setting the motoserver s3 port
+      # https://developer.apple.com/forums/thread/682332
+      export MOTO_PORT="${key#*=}"
+      shift # past argument=value
+      ;;
       *)    # unknown option
       POSITIONAL+=("$1") # save it in an array for later
       shift # past argument


### PR DESCRIPTION
This is to help developers with port binding issues on macOS. Motoserver is set to use port 5000 by default. [Monterey uses 5000 for Control Center purposes](https://developer.apple.com/forums/thread/682332). As a result, running the test script will cause a `bind: address already in use` error.

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [x] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): Update test runner script


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Motoserver s3 uses port 5000 (default). MacOS uses that port (Monterey for sure, probably others?) and causes a conflict when running the test script
Issue Number: [GTC-1893](https://gfw.atlassian.net/browse/GTC-1893)

Sample terminal output:
```bash
[+] Running 3/3
 ⠿ Network gfw-data-api_test_default        Created                                                                                                                    0.0s
 ⠿ Container gfw-data-api-test-database-12  Created                                                                                                                    0.1s
 ⠿ Container motoserver-s3                  Created                                                                                                                    0.1s
[+] Running 1/2
 ⠿ Container gfw-data-api-test-database-12  Started                                                                                                                    0.3s
 ⠸ Container motoserver-s3                  Starting                                                                                                                   0.3s
[+] Running 3/2from daemon: Ports are not available: exposing port TCP 0.0.0.0:5000 -> 0.0.0.0:0: listen tcp 0.0.0.0:5000: bind: address already in use
 ⠿ Container gfw-data-api-test-database-12  Removed                                                                                                                   10.2s
 ⠿ Container motoserver-s3                  Removed                                                                                                                    0.0s
 ⠿ Network gfw-data-api_test_default        Removed  
```


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
Users can now explicitly set the port that the `host` machine should use. The default is `5000` so this is not a breaking change:
Current example usage (host port will be `5000`):
$> `./scripts/test --no_build`
Explicitly setting the port:
$> `./scripts/test --no_build --moto-port=5500`
## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
