### PR TITLE
Revert "Change back to ec2s for Batch... again"

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -166,7 +166,7 @@ module "batch_data_lake_writer" {
   tags                     = local.batch_tags
   use_ephemeral_storage    = true
   # SPOT is actually the default, this is just a placeholder until GTC-1791 is done
-  launch_type              = "EC2"
+  launch_type              = "SPOT"
   compute_environment_name = "data_lake_writer"
 }
 


### PR DESCRIPTION
Reverts wri/gfw-data-api#317
Net effect: Use spot instances instead of EC2s