### PR TITLE
GTC-1864 Paginate Assets by Dataset and Version

### DIFF
--- a/app/routes/assets/assets.py
+++ b/app/routes/assets/assets.py
@@ -35,7 +35,7 @@ async def get_assets(
         default=None,
         alias="page[size]",
         ge=1,
-        description="The number of datasets per page. Default is `10`.",
+        description="The number of assets per page. Default is `10`.",
     ),
 ) -> Union[PaginatedAssetsResponse, AssetsResponse]:
     """Get all assets for a given dataset version.

--- a/app/routes/datasets/asset.py
+++ b/app/routes/datasets/asset.py
@@ -60,7 +60,7 @@ async def get_version_assets(
         default=None,
         alias="page[size]",
         ge=1,
-        description="The number of datasets per page. Default is `10`.",
+        description="The number of assets per page. Default is `10`.",
     ),
 ) -> Union[PaginatedAssetsResponse, AssetsResponse]:
     """Get all assets for a given dataset version.

--- a/app/routes/datasets/asset.py
+++ b/app/routes/datasets/asset.py
@@ -9,9 +9,9 @@ cannot rely on full integrity. We can only assume that unmanaged are
 based on the same version and do not know the processing history.
 """
 
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, Union
 
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Request
 from fastapi.responses import ORJSONResponse
 
 from ...authentication.token import is_admin
@@ -23,11 +23,13 @@ from ...models.pydantic.assets import (
     AssetResponse,
     AssetsResponse,
     AssetType,
+    PaginatedAssetsResponse,
 )
 from ...routes import dataset_version_dependency
 from ...tasks.assets import put_asset
+from ...utils.paginate import paginate_collection
 from ...utils.path import get_asset_uri
-from ..assets import asset_response, assets_response
+from ..assets import asset_response, assets_response, paginated_assets_response
 from . import (
     validate_creation_options,
     verify_asset_dependencies,
@@ -41,7 +43,7 @@ router = APIRouter()
     "/{dataset}/{version}/assets",
     response_class=ORJSONResponse,
     tags=["Versions"],
-    response_model=AssetsResponse,
+    response_model=Union[PaginatedAssetsResponse, AssetsResponse],
 )
 async def get_version_assets(
     *,
@@ -50,8 +52,23 @@ async def get_version_assets(
     asset_uri: Optional[str] = Query(None),
     is_latest: Optional[bool] = Query(None),
     is_default: Optional[bool] = Query(None),
-):
-    """Get all assets for a given dataset version."""
+    request: Request,
+    page_number: Optional[int] = Query(
+        default=None, alias="page[number]", ge=1, description="The page number."
+    ),
+    page_size: Optional[int] = Query(
+        default=None,
+        alias="page[size]",
+        ge=1,
+        description="The number of datasets per page. Default is `10`.",
+    ),
+) -> Union[PaginatedAssetsResponse, AssetsResponse]:
+    """Get all assets for a given dataset version.
+
+    Will attempt to paginate if `page[size]` or `page[number]` is
+    provided. Otherwise, it will attempt to return the entire list of
+    assets in the response.
+    """
 
     dataset, version = dv
 
@@ -60,11 +77,31 @@ async def get_version_assets(
     else:
         a_t = None
 
-    data: List[ORMAsset] = await assets.get_assets_by_filter(
+    if page_number or page_size:
+        try:
+            data, links, meta = await paginate_collection(
+                paged_items_fn=await assets.get_filtered_assets_fn(
+                    dataset, version, a_t, asset_uri, is_latest, is_default
+                ),
+                item_count_fn=await assets.count_filtered_assets_fn(
+                    dataset, version, a_t, asset_uri, is_latest, is_default
+                ),
+                request_url=f"{request.url}".split("?")[0],
+                page=page_number,
+                size=page_size,
+            )
+
+            return await paginated_assets_response(
+                assets_orm=data, links=links, meta=meta
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    all_assets: List[ORMAsset] = await assets.get_assets_by_filter(
         dataset, version, a_t, asset_uri, is_latest, is_default
     )
 
-    return await assets_response(data)
+    return await assets_response(all_assets)
 
 
 @router.post(

--- a/tests_v2/unit/app/routes/datasets/datasets/assets/test_dataset_assets_with_no_pagination.py
+++ b/tests_v2/unit/app/routes/datasets/datasets/assets/test_dataset_assets_with_no_pagination.py
@@ -1,0 +1,13 @@
+import pytest as pytest
+from httpx import AsyncClient
+
+from app.models.pydantic.assets import AssetsResponse
+
+
+@pytest.mark.asyncio
+async def test_get_assets_returns_assets_of_a_specific_dataset_and_version_response(
+    async_client: AsyncClient, generic_vector_source_version
+) -> None:
+    dataset_name, dataset_version, _ = generic_vector_source_version
+    resp = await async_client.get(f"/dataset/{dataset_name}/{dataset_version}/assets")
+    assert AssetsResponse(**resp.json())

--- a/tests_v2/unit/app/routes/datasets/datasets/assets/test_dataset_assets_with_pagination.py
+++ b/tests_v2/unit/app/routes/datasets/datasets/assets/test_dataset_assets_with_pagination.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict, Tuple
+
 import pytest as pytest
 from httpx import AsyncClient
 
@@ -11,7 +13,8 @@ def assets_for(dataset):
 
 @pytest.mark.asyncio
 async def test_adding_page_number_returns_paginated_assets_response(
-    async_client: AsyncClient, generic_vector_source_version
+    async_client: AsyncClient,
+    generic_vector_source_version: Tuple[str, str, Dict[str, Any]],
 ) -> None:
 
     resp = await async_client.get(
@@ -22,7 +25,8 @@ async def test_adding_page_number_returns_paginated_assets_response(
 
 @pytest.mark.asyncio
 async def test_adding_size_parameter_returns_paginated_assets_response(
-    async_client: AsyncClient, generic_vector_source_version
+    async_client: AsyncClient,
+    generic_vector_source_version: Tuple[str, str, Dict[str, Any]],
 ) -> None:
 
     resp = await async_client.get(
@@ -33,7 +37,8 @@ async def test_adding_size_parameter_returns_paginated_assets_response(
 
 @pytest.mark.asyncio
 async def test_adding_both_page_and_size_parameter_returns_paginated_assets_response(
-    async_client: AsyncClient, generic_vector_source_version
+    async_client: AsyncClient,
+    generic_vector_source_version: Tuple[str, str, Dict[str, Any]],
 ) -> None:
 
     resp = await async_client.get(
@@ -45,7 +50,8 @@ async def test_adding_both_page_and_size_parameter_returns_paginated_assets_resp
 
 @pytest.mark.asyncio
 async def test_get_paginated_asset_with_pagesize_less_than_1_returns_4xx(
-    async_client: AsyncClient, generic_vector_source_version
+    async_client: AsyncClient,
+    generic_vector_source_version: Tuple[str, str, Dict[str, Any]],
 ) -> None:
 
     resp = await async_client.get(
@@ -56,7 +62,8 @@ async def test_get_paginated_asset_with_pagesize_less_than_1_returns_4xx(
 
 @pytest.mark.asyncio
 async def test_get_paginated_asset_with_pagenumber_less_than_1_returns_4xx(
-    async_client: AsyncClient, generic_vector_source_version
+    async_client: AsyncClient,
+    generic_vector_source_version: Tuple[str, str, Dict[str, Any]],
 ) -> None:
 
     resp = await async_client.get(
@@ -67,7 +74,8 @@ async def test_get_paginated_asset_with_pagenumber_less_than_1_returns_4xx(
 
 @pytest.mark.asyncio
 async def test_get_paginated_asset_with_pagenumber_more_than_max_pages_returns_4xx(
-    async_client: AsyncClient, generic_vector_source_version
+    async_client: AsyncClient,
+    generic_vector_source_version: Tuple[str, str, Dict[str, Any]],
 ) -> None:
 
     resp = await async_client.get(

--- a/tests_v2/unit/app/routes/datasets/datasets/assets/test_dataset_assets_with_pagination.py
+++ b/tests_v2/unit/app/routes/datasets/datasets/assets/test_dataset_assets_with_pagination.py
@@ -1,0 +1,88 @@
+import pytest as pytest
+from httpx import AsyncClient
+
+from app.models.pydantic.assets import PaginatedAssetsResponse
+
+
+@pytest.mark.xfail
+@pytest.mark.asyncio
+async def test_adding_page_number_returns_paginated_assets_response(
+    async_client: AsyncClient, generic_vector_source_version
+) -> None:
+
+    dataset_name, dataset_version, _ = generic_vector_source_version
+    resp = await async_client.get(
+        f"/dataset/{dataset_name}/{dataset_version}/assets",
+        params=[("page[number]", "1")],
+    )
+    assert PaginatedAssetsResponse(**resp.json())
+
+
+@pytest.mark.xfail
+@pytest.mark.asyncio
+async def test_adding_size_parameter_returns_paginated_assets_response(
+    async_client: AsyncClient, generic_vector_source_version
+) -> None:
+
+    dataset_name, dataset_version, _ = generic_vector_source_version
+    resp = await async_client.get(
+        f"/dataset/{dataset_name}/{dataset_version}/assets",
+        params=[("page[size]", "10")],
+    )
+    assert PaginatedAssetsResponse(**resp.json())
+
+
+@pytest.mark.xfail
+@pytest.mark.asyncio
+async def test_adding_both_page_and_size_parameter_returns_paginated_assets_response(
+    async_client: AsyncClient, generic_vector_source_version
+) -> None:
+
+    dataset_name, dataset_version, _ = generic_vector_source_version
+    resp = await async_client.get(
+        f"/dataset/{dataset_name}/{dataset_version}/assets",
+        params=[("page[number]", "1"), ("page[size]", "10")],
+    )
+    assert PaginatedAssetsResponse(**resp.json())
+
+
+@pytest.mark.xfail
+@pytest.mark.asyncio
+async def test_get_paginated_asset_with_pagesize_less_than_1_returns_4xx(
+    async_client: AsyncClient, generic_vector_source_version
+) -> None:
+
+    dataset_name, dataset_version, _ = generic_vector_source_version
+    resp = await async_client.get(
+        f"/dataset/{dataset_name}/{dataset_version}/assets",
+        params=[("page[size]", "0")],
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.xfail
+@pytest.mark.asyncio
+async def test_get_paginated_asset_with_pagenumber_less_than_1_returns_4xx(
+    async_client: AsyncClient, generic_vector_source_version
+) -> None:
+
+    dataset_name, dataset_version, _ = generic_vector_source_version
+    resp = await async_client.get(
+        f"/dataset/{dataset_name}/{dataset_version}/assets",
+        params=[("page[number]", "0")],
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.xfail
+@pytest.mark.asyncio
+async def test_get_paginated_asset_with_pagenumber_more_than_max_pages_returns_4xx(
+    async_client: AsyncClient, generic_vector_source_version
+) -> None:
+
+    dataset_name, dataset_version, _ = generic_vector_source_version
+    resp = await async_client.get(
+        f"/dataset/{dataset_name}/{dataset_version}/assets",
+        params=[("page[number]", "100")],
+    )
+    assert resp.status_code == 422

--- a/tests_v2/unit/app/routes/datasets/datasets/assets/test_dataset_assets_with_pagination.py
+++ b/tests_v2/unit/app/routes/datasets/datasets/assets/test_dataset_assets_with_pagination.py
@@ -4,7 +4,6 @@ from httpx import AsyncClient
 from app.models.pydantic.assets import PaginatedAssetsResponse
 
 
-@pytest.mark.xfail
 @pytest.mark.asyncio
 async def test_adding_page_number_returns_paginated_assets_response(
     async_client: AsyncClient, generic_vector_source_version
@@ -18,7 +17,6 @@ async def test_adding_page_number_returns_paginated_assets_response(
     assert PaginatedAssetsResponse(**resp.json())
 
 
-@pytest.mark.xfail
 @pytest.mark.asyncio
 async def test_adding_size_parameter_returns_paginated_assets_response(
     async_client: AsyncClient, generic_vector_source_version
@@ -32,7 +30,6 @@ async def test_adding_size_parameter_returns_paginated_assets_response(
     assert PaginatedAssetsResponse(**resp.json())
 
 
-@pytest.mark.xfail
 @pytest.mark.asyncio
 async def test_adding_both_page_and_size_parameter_returns_paginated_assets_response(
     async_client: AsyncClient, generic_vector_source_version
@@ -46,7 +43,6 @@ async def test_adding_both_page_and_size_parameter_returns_paginated_assets_resp
     assert PaginatedAssetsResponse(**resp.json())
 
 
-@pytest.mark.xfail
 @pytest.mark.asyncio
 async def test_get_paginated_asset_with_pagesize_less_than_1_returns_4xx(
     async_client: AsyncClient, generic_vector_source_version
@@ -60,7 +56,6 @@ async def test_get_paginated_asset_with_pagesize_less_than_1_returns_4xx(
     assert resp.status_code == 422
 
 
-@pytest.mark.xfail
 @pytest.mark.asyncio
 async def test_get_paginated_asset_with_pagenumber_less_than_1_returns_4xx(
     async_client: AsyncClient, generic_vector_source_version
@@ -74,7 +69,6 @@ async def test_get_paginated_asset_with_pagenumber_less_than_1_returns_4xx(
     assert resp.status_code == 422
 
 
-@pytest.mark.xfail
 @pytest.mark.asyncio
 async def test_get_paginated_asset_with_pagenumber_more_than_max_pages_returns_4xx(
     async_client: AsyncClient, generic_vector_source_version

--- a/tests_v2/unit/app/routes/datasets/datasets/assets/test_dataset_assets_with_pagination.py
+++ b/tests_v2/unit/app/routes/datasets/datasets/assets/test_dataset_assets_with_pagination.py
@@ -4,15 +4,18 @@ from httpx import AsyncClient
 from app.models.pydantic.assets import PaginatedAssetsResponse
 
 
+def assets_for(dataset):
+    dataset_name, dataset_version, _ = dataset
+    return f"/dataset/{dataset_name}/{dataset_version}/assets"
+
+
 @pytest.mark.asyncio
 async def test_adding_page_number_returns_paginated_assets_response(
     async_client: AsyncClient, generic_vector_source_version
 ) -> None:
 
-    dataset_name, dataset_version, _ = generic_vector_source_version
     resp = await async_client.get(
-        f"/dataset/{dataset_name}/{dataset_version}/assets",
-        params=[("page[number]", "1")],
+        assets_for(generic_vector_source_version), params=[("page[number]", "1")]
     )
     assert PaginatedAssetsResponse(**resp.json())
 
@@ -22,10 +25,8 @@ async def test_adding_size_parameter_returns_paginated_assets_response(
     async_client: AsyncClient, generic_vector_source_version
 ) -> None:
 
-    dataset_name, dataset_version, _ = generic_vector_source_version
     resp = await async_client.get(
-        f"/dataset/{dataset_name}/{dataset_version}/assets",
-        params=[("page[size]", "10")],
+        assets_for(generic_vector_source_version), params=[("page[size]", "10")]
     )
     assert PaginatedAssetsResponse(**resp.json())
 
@@ -35,9 +36,8 @@ async def test_adding_both_page_and_size_parameter_returns_paginated_assets_resp
     async_client: AsyncClient, generic_vector_source_version
 ) -> None:
 
-    dataset_name, dataset_version, _ = generic_vector_source_version
     resp = await async_client.get(
-        f"/dataset/{dataset_name}/{dataset_version}/assets",
+        assets_for(generic_vector_source_version),
         params=[("page[number]", "1"), ("page[size]", "10")],
     )
     assert PaginatedAssetsResponse(**resp.json())
@@ -48,10 +48,8 @@ async def test_get_paginated_asset_with_pagesize_less_than_1_returns_4xx(
     async_client: AsyncClient, generic_vector_source_version
 ) -> None:
 
-    dataset_name, dataset_version, _ = generic_vector_source_version
     resp = await async_client.get(
-        f"/dataset/{dataset_name}/{dataset_version}/assets",
-        params=[("page[size]", "0")],
+        assets_for(generic_vector_source_version), params=[("page[size]", "0")]
     )
     assert resp.status_code == 422
 
@@ -61,10 +59,8 @@ async def test_get_paginated_asset_with_pagenumber_less_than_1_returns_4xx(
     async_client: AsyncClient, generic_vector_source_version
 ) -> None:
 
-    dataset_name, dataset_version, _ = generic_vector_source_version
     resp = await async_client.get(
-        f"/dataset/{dataset_name}/{dataset_version}/assets",
-        params=[("page[number]", "0")],
+        assets_for(generic_vector_source_version), params=[("page[number]", "0")]
     )
     assert resp.status_code == 422
 
@@ -74,9 +70,7 @@ async def test_get_paginated_asset_with_pagenumber_more_than_max_pages_returns_4
     async_client: AsyncClient, generic_vector_source_version
 ) -> None:
 
-    dataset_name, dataset_version, _ = generic_vector_source_version
     resp = await async_client.get(
-        f"/dataset/{dataset_name}/{dataset_version}/assets",
-        params=[("page[number]", "100")],
+        assets_for(generic_vector_source_version), params=[("page[number]", "100")]
     )
     assert resp.status_code == 422


### PR DESCRIPTION
# Testing
OpenAPI docs:
#tag/Versions/operation/get_version_assets_dataset__dataset___version__assets_get
1st page of assets: 
:dataset/:version/assets?page[number]=1
Working example:
https://x6nf03dcf5.execute-api.us-east-1.amazonaws.com/deploy_GTC_1864_pag_assets_by_dset/dataset/birdlife_biodiversity_significance/v201909/assets?page[number]=1&page[size]=5
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [x] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
There is no option to paginate the results.
Issue Number: [GTC-1864](https://gfw.atlassian.net/browse/GTC-1864)


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
- Pagination can now be accomplished by passing with `page[number]` or `page[size]` query params to the `/assets` endpoint

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

