### PR TITLE
remove GW authorizer from query endpoints

### DIFF
--- a/terraform/api_gateway.tf
+++ b/terraform/api_gateway.tf
@@ -48,7 +48,7 @@ module "query_get" {
 
   require_api_key = false
   http_method = "GET"
-  authorization = "CUSTOM"
+  authorization   = "NONE"
 
   integration_parameters = {
     "integration.request.path.version" = "method.request.path.version"
@@ -75,7 +75,7 @@ module "query_post" {
 
   require_api_key = false
   http_method = "POST"
-  authorization = "CUSTOM"
+  authorization   = "NONE"
 
   integration_parameters = {
     "integration.request.path.version" = "method.request.path.version"


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [ ] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [X] Check the commit's or even all commits' message styles matches our requested structure.
- [X] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
If API Gateway lambda authorizer is attached to an endpoint, requests count towards rate limiting quota even if the endpoint doesn't require API key.

Issue Number: [GTC-2073](https://gfw.atlassian.net/browse/GTC-2073)


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Requests don't count towards rate limiting quota if endpoint doesn't require API key.


## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
