### PR TITLE
GTC-1866: fix: Remove extra quotes from error message

### DIFF
--- a/terraform/modules/api_gateway/resource/main.tf
+++ b/terraform/modules/api_gateway/resource/main.tf
@@ -94,7 +94,7 @@ resource "aws_api_gateway_gateway_response" "integration_timeout" {
     "application/json" = <<EOF
 {
   "status": "failed",
-  "message": "$context.error.messageString : Use the pagination query parameters when available. See the API documentation."
+  "message": "$context.error.message : Use the pagination query parameters when available. See the API documentation."
 }
 EOF
   }


### PR DESCRIPTION
I didn't notice the subtle difference between the variables: https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-mapping-template-reference.html

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [x] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The error message for an integration timeout has a double set of quotation marks. It's not valid JSON:
Request: `https://data-api.globalforestwatch.org/assets`
Response:
```json
{
    "status": "failed",
    "message": " "Endpoint request timed out" : Use the pagination query parameters when available. See the API documentation."
}
```
Issue Number: [GTC-1866](https://gfw.atlassian.net/browse/GTC-1866)


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
The new property should not have quotation marks.


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
