### PR TITLE
tiles.geojson coords are epsg:4326, but determine tiles' ACTUAL CRS d…

### DIFF
--- a/batch/python/resample.py
+++ b/batch/python/resample.py
@@ -620,15 +620,17 @@ def resample(
     # extent of the source
 
     # NOTE: pixetl seems to always write features in tiles.geojson in
-    # epsg:4326 coordinates. If that ever changes, something similar to
-    # the following may be helpful:
-    # with rasterio.open(overall_vrt) as src_vrt:
-    #     source_crs = src_vrt.crs
-    source_crs: CRS = TILES_GEOJSON_CRS
+    # epsg:4326 coordinates (even when the tiles themselves are
+    # epsg:3857). If that ever changes, update TILES_GEOJSON_CRS
+    # or get the CRS from tiles.geojson dynamically
     target_grid_name = f"zoom_{target_zoom}"
     tiles_in_target_grid: List[Tuple[str, Bounds]] = intersecting_tiles(
-        source_crs, src_tiles_info, target_grid_name, logger
+        TILES_GEOJSON_CRS, src_tiles_info, target_grid_name, logger
     )
+
+    # Now get the ACTUAL CRS of the source tiles
+    with rasterio.open(overall_vrt) as src_vrt:
+        source_crs: CRS = src_vrt.crs
 
     bucket, _ = get_s3_path_parts(source_uri)
 


### PR DESCRIPTION
…ynamically

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [x] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
EPSG:4326 is incorrectly specified as the source CRS of web-mercator tiles

Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

-The source CRS is set as web-mercator, while the source tile coordinates as taken from tiles.geojson are interpreted as EPSG:4326
-Clarifying comments

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
