### PR TITLE
Revert "Re-upgrade postgres dockerfile in use for new Python but older csvkit"

### DIFF
--- a/batch/postgresql-client.dockerfile
+++ b/batch/postgresql-client.dockerfile
@@ -1,4 +1,4 @@
-FROM globalforestwatch/data-api-postgresql:v1.0.4
+FROM globalforestwatch/data-api-postgresql:1.0.2
 
 # Copy scripts
 COPY ./batch/scripts/ /opt/scripts/


### PR DESCRIPTION
Reverts wri/gfw-data-api#371

This puts us back on the old image which uses Python 3.8, csvkit 1.0.5