### PR TITLE
Allow multiple band intensity symbologies

### DIFF
--- a/app/models/enum/creation_options.py
+++ b/app/models/enum/creation_options.py
@@ -83,3 +83,4 @@ class ColorMapType(str, Enum):
     date_conf_intensity_multi_8 = "date_conf_intensity_multi_8"
     date_conf_intensity_multi_16 = "date_conf_intensity_multi_16"
     year_intensity = "year_intensity"
+    value_intensity = "value_intensity"

--- a/app/tasks/raster_tile_cache_assets/raster_tile_cache_assets.py
+++ b/app/tasks/raster_tile_cache_assets/raster_tile_cache_assets.py
@@ -217,10 +217,10 @@ async def raster_tile_cache_validator(
     symbology_type = input_data["creation_options"].get("symbology", {}).get("type")
     if symbology_type:
         symbology_info = symbology_constructor[symbology_type]
-        req_input_bands: Optional[int] = symbology_info.req_input_bands
+        req_input_bands: Optional[List[int]] = symbology_info.req_input_bands
 
         if req_input_bands and (
-            req_input_bands != source_asset.creation_options.get("band_count", 1)
+            req_input_bands in source_asset.creation_options.get("band_count", [1])
         ):
             message = (
                 f"Symbology type {symbology_type} requires a source "

--- a/app/tasks/raster_tile_cache_assets/raster_tile_cache_assets.py
+++ b/app/tasks/raster_tile_cache_assets/raster_tile_cache_assets.py
@@ -220,7 +220,7 @@ async def raster_tile_cache_validator(
         req_input_bands: Optional[List[int]] = symbology_info.req_input_bands
 
         if req_input_bands and (
-            req_input_bands in source_asset.creation_options.get("band_count", [1])
+            source_asset.creation_options.get("band_count", 1) in req_input_bands
         ):
             message = (
                 f"Symbology type {symbology_type} requires a source "

--- a/app/tasks/raster_tile_cache_assets/raster_tile_cache_assets.py
+++ b/app/tasks/raster_tile_cache_assets/raster_tile_cache_assets.py
@@ -218,12 +218,12 @@ async def raster_tile_cache_validator(
     if symbology_type:
         symbology_info = symbology_constructor[symbology_type]
         req_input_bands: Optional[List[int]] = symbology_info.req_input_bands
+        band_count = source_asset.creation_options.get("band_count", 1)
 
-        if req_input_bands and (
-            source_asset.creation_options.get("band_count", 1) in req_input_bands
-        ):
+        if req_input_bands and (band_count not in req_input_bands):
             message = (
                 f"Symbology type {symbology_type} requires a source "
-                f"asset with {req_input_bands} bands"
+                f"asset with one of {req_input_bands} bands, but has "
+                f"{band_count} band(s)."
             )
             raise HTTPException(status_code=400, detail=message)

--- a/app/tasks/raster_tile_cache_assets/symbology.py
+++ b/app/tasks/raster_tile_cache_assets/symbology.py
@@ -46,7 +46,7 @@ SymbologyFuncType = Callable[
 
 class SymbologyInfo(NamedTuple):
     bit_depth: Literal[8, 16]
-    req_input_bands: Optional[int]
+    req_input_bands: Optional[List[int]]
     function: SymbologyFuncType
 
 
@@ -376,7 +376,7 @@ async def date_conf_intensity_multi_8_symbology(
     return [*intensity_jobs, *merge_jobs], final_asset_uri
 
 
-async def year_intensity_symbology(
+async def value_intensity_symbology(
     dataset: str,
     version: str,
     pixel_meaning: str,
@@ -396,7 +396,14 @@ async def year_intensity_symbology(
     Tree Cover Loss dataset.
     """
 
-    intensity_calc_string = "(A > 0) * 255"
+    if source_asset_co.band_count == 1:
+        intensity_calc_string = "(A > 0) * 255"
+    elif source_asset_co.band_count == 2:
+        intensity_calc_string = "((A > 0) & (B > 0)) * 255"
+    else:
+        raise RuntimeError(
+            f"Too many bands in source asset ({source_asset_co.band_count}), max 2 bands supported."
+        )
 
     intensity_jobs, intensity_uri = await _create_intensity_asset(
         dataset,
@@ -412,10 +419,19 @@ async def year_intensity_symbology(
 
     # The resulting raster channels are as follows:
     # 1. Intensity
-    # 2. All zeros
-    # 3. Year
+    # 2. Values in second band of sources asset, or all zeros if only one band
+    # 3. Values in first band of source assets (B for backwards compatibility)
     # 4. Alpha (which is set to 255 everywhere intensity is >0)
-    merge_calc_string = "np.ma.array([B, np.ma.zeros(A.shape, dtype='uint8'), A, (B > 0) * 255], fill_value=0).astype('uint8')"
+    if source_asset_co.band_count == 1:
+        merge_calc_string = "np.ma.array([B, np.ma.zeros(A.shape, dtype='uint8'), A, (B > 0) * 255], fill_value=0).astype('uint8')"
+    elif source_asset_co.band_count == 2:
+        merge_calc_string = (
+            "np.ma.array([C, A, B, (B > 0) * 255], fill_value=0).astype('uint8')"
+        )
+    else:
+        raise RuntimeError(
+            f"Too many bands in source asset ({source_asset_co.band_count}), max 2 bands supported."
+        )
 
     wm_source_uri: str = get_asset_uri(
         dataset,
@@ -544,6 +560,7 @@ async def _create_intensity_asset(
             "no_data": None,
             "pixel_meaning": f"intensity_{pixel_meaning}",
             "resampling": resampling,
+            "band_count": 1,
         },
     )
 
@@ -644,16 +661,17 @@ async def _merge_assets(
 
 _symbology_constructor: Dict[str, SymbologyInfo] = {
     ColorMapType.date_conf_intensity: SymbologyInfo(
-        8, 1, date_conf_intensity_symbology
+        8, [1], date_conf_intensity_symbology
     ),
     ColorMapType.date_conf_intensity_multi_8: SymbologyInfo(
-        8, 1, date_conf_intensity_multi_8_symbology
+        8, [1], date_conf_intensity_multi_8_symbology
     ),
-    ColorMapType.year_intensity: SymbologyInfo(8, 1, year_intensity_symbology),
-    ColorMapType.gradient: SymbologyInfo(8, 1, colormap_symbology),
-    ColorMapType.gradient_intensity: SymbologyInfo(8, 1, colormap_symbology),
-    ColorMapType.discrete: SymbologyInfo(8, 1, colormap_symbology),
-    ColorMapType.discrete_intensity: SymbologyInfo(8, 1, colormap_symbology),
+    ColorMapType.year_intensity: SymbologyInfo(8, [1], value_intensity_symbology),
+    ColorMapType.value_intensity: SymbologyInfo(8, [1, 2], value_intensity_symbology),
+    ColorMapType.gradient: SymbologyInfo(8, [1], colormap_symbology),
+    ColorMapType.gradient_intensity: SymbologyInfo(8, [1], colormap_symbology),
+    ColorMapType.discrete: SymbologyInfo(8, [1], colormap_symbology),
+    ColorMapType.discrete_intensity: SymbologyInfo(8, [1], colormap_symbology),
 }
 
 symbology_constructor: DefaultDict[str, SymbologyInfo] = defaultdict(


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [X] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [X] Check the commit's or even all commits' message styles matches our requested structure.
- [X] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
`year_intensity` symbology option only works with single band rasters, and the name also implies it works only on years, even though it works on any single band integer raster. 

Issue Number: GTC-2296


## What is the new behavior?

Refactor `year_intensity` to `value_intensity` symbology which generically will create intensity symbology from 1 or 2 band rasters.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No
