### PR TITLE
Otf bug fix and optimization

### DIFF
--- a/app/models/orm/queries/raster_assets.py
+++ b/app/models/orm/queries/raster_assets.py
@@ -1,23 +1,28 @@
 from ....application import db
+from ...enum.pixetl import Grid
 
-_raster_assets_sql = """
-SELECT
-  assets.asset_id,
-  assets.dataset,
-  assets.version,
-  creation_options,
-  asset_uri,
-  rb.values_table
-FROM
-  assets
-  LEFT JOIN asset_metadata am
-    ON am.asset_id = assets.asset_id
-  JOIN versions
-    ON versions.version = assets.version
-  LEFT JOIN raster_band_metadata rb
-    ON rb.asset_metadata_id = am.id
-  WHERE versions.is_latest = true
-  AND assets.asset_type = 'Raster tile set'
-"""
+sql = """
+    SELECT
+      assets.asset_id,
+      assets.dataset,
+      assets.version,
+      creation_options,
+      asset_uri,
+      rb.values_table
+    FROM
+      assets
+      LEFT JOIN asset_metadata am
+        ON am.asset_id = assets.asset_id
+      JOIN versions
+        ON versions.dataset = assets.dataset
+        AND versions.version = assets.version
+      LEFT JOIN raster_band_metadata rb
+        ON rb.asset_metadata_id = am.id
+      WHERE versions.is_latest = true
+      AND assets.asset_type = 'Raster tile set'
+      AND assets.creation_options->>'pixel_meaning' NOT LIKE '%tcd%'
+      AND assets.creation_options->>'grid' = :grid
+    """
 
-latest_raster_tile_sets = db.text(_raster_assets_sql)
+
+latest_raster_tile_sets = db.text(sql)

--- a/app/routes/datasets/queries.py
+++ b/app/routes/datasets/queries.py
@@ -647,19 +647,11 @@ def _get_default_layer(dataset, pixel_meaning):
 
 async def _get_data_environment(grid: Grid) -> DataEnvironment:
     # get all Raster tile set assets
-    latest_tile_sets = await db.all(latest_raster_tile_sets)
+    latest_tile_sets = await db.all(latest_raster_tile_sets, {"grid": grid})
     # create layers
     layers: List[Layer] = []
     for row in latest_tile_sets:
         creation_options = row.creation_options
-        if creation_options["grid"] != grid:
-            # skip if not on the right grid
-            continue
-
-        # TODO skip intermediate raster for tile cache until field is in metadata
-        if "tcd" in creation_options["pixel_meaning"]:
-            continue
-
         # only include single band rasters
         if creation_options.get("band_count", 1) > 1:
             continue

--- a/tests_v2/fixtures/otf_payload/otf_payload.py
+++ b/tests_v2/fixtures/otf_payload/otf_payload.py
@@ -1,0 +1,39 @@
+environment = [
+    {
+        "name": "my_first_dataset__date_conf",
+        "no_data": 0,
+        "raster_table": None,
+        "decode_expression": "",
+        "encode_expression": "",
+        "source_uri": "s3://gfw-data-lake-test/my_first_dataset/v1/raster/epsg-4326/10/40000/date_conf/geotiff/{tile_id}.tif",
+        "grid": "10/40000",
+        "tile_scheme": "nw",
+    },
+    {
+        "name": "my_first_dataset__date",
+        "no_data": 0,
+        "raster_table": None,
+        "decode_expression": "(A + 16435).astype('datetime64[D]').astype(str)",
+        "encode_expression": "(datetime64(A) - 16435).astype(uint16)",
+        "source_layer": "my_first_dataset__date_conf",
+        "calc": "A % 10000",
+    },
+    {
+        "name": "my_first_dataset__confidence",
+        "no_data": 0,
+        "raster_table": {
+            "rows": [
+                {"value": 2, "meaning": "nominal"},
+                {"value": 3, "meaning": "high"},
+                {"value": 4, "meaning": "highest"},
+            ],
+            "default_meaning": "not_detected",
+        },
+        "decode_expression": "",
+        "encode_expression": "",
+        "source_layer": "my_first_dataset__date_conf",
+        "calc": "floor(A / 10000).astype(uint8)",
+    },
+]
+
+sql = "select sum(area__ha) from data where is__umd_regional_primary_forest_2001 != 'false' and umd_tree_cover_density_2000__threshold >= 30 and umd_tree_cover_loss__year >= 2001 group by umd_tree_cover_loss__year"

--- a/tests_v2/unit/app/routes/analysis/test_analysis.py
+++ b/tests_v2/unit/app/routes/analysis/test_analysis.py
@@ -109,3 +109,4 @@ async def test_raster_analysis_payload_shape(
         payload = mock_invoke_lambda.call_args.args[1]
         assert payload["query"] == sql
         assert payload["environment"] == environment
+        assert payload["geometry"] == geostore_common.geojson

--- a/tests_v2/unit/app/routes/analysis/test_analysis.py
+++ b/tests_v2/unit/app/routes/analysis/test_analysis.py
@@ -1,9 +1,16 @@
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
-from httpx import AsyncClient
+from httpx import AsyncClient, Response
+from unittest.mock import AsyncMock, Mock
 
+from app.models.enum.pixetl import Grid
 from app.routes.datasets import queries
+from app.utils import geostore
 from tests_v2.utils import invoke_lambda_mocked
+from tests_v2.fixtures.creation_options.versions import RASTER_CREATION_OPTIONS
+from tests_v2.fixtures.sample_rw_geostore_response import geostore_common
+from tests_v2.fixtures.otf_payload.otf_payload import sql, environment
+from tests_v2.utils import custom_raster_version
 
 
 @pytest.mark.skip("Temporarily skip until we require API keys")
@@ -68,3 +75,37 @@ async def test_analysis_with_huge_geostore(
     )
 
     assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_raster_analysis_payload_shape(
+    generic_dataset, async_client: AsyncClient, monkeypatch: MonkeyPatch
+):
+    dataset_name, _ = generic_dataset
+    pixel_meaning: str = "date_conf"
+    no_data_value = 0
+
+    async with custom_raster_version(
+        async_client,
+        dataset_name,
+        monkeypatch,
+        pixel_meaning=pixel_meaning,
+        no_data=no_data_value,
+    ) as version_name:
+
+        mock_invoke_lambda = AsyncMock(
+            return_value=Response(200, json={"status": "success", "data": []})
+        )
+        monkeypatch.setattr(queries, "invoke_lambda", mock_invoke_lambda)
+
+        mock_rw_get_geostore = Mock(
+            geostore.rw_api.get_geostore, return_value=geostore_common
+        )
+        monkeypatch.setattr(geostore.rw_api, "get_geostore", mock_rw_get_geostore)
+
+        _ = await async_client.get(
+            f"/analysis/zonal/17076d5ea9f214a5bdb68cc40433addb?geostore_origin=rw&group_by=umd_tree_cover_loss__year&filters=is__umd_regional_primary_forest_2001&filters=umd_tree_cover_density_2000__30&sum=area__ha&start_date=2001"
+        )
+        payload = mock_invoke_lambda.call_args.args[1]
+        assert payload["query"] == sql
+        assert payload["environment"] == environment


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [x] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Plain sql query for raster tile sets had a bug returning duplicate tile sets that impacted OTF


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Fixed sql query bug now returning correct number of OTF layers
- Optimized data_environment function by excluding intermediate tile sets from query result

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
