### PR TITLE
GTC-2443 Fix /fields query for version with only rasters

### DIFF
--- a/app/routes/datasets/queries.py
+++ b/app/routes/datasets/queries.py
@@ -667,9 +667,11 @@ def _get_default_layer(dataset, pixel_meaning):
 
 
 async def _get_data_environment(grid: Grid) -> DataEnvironment:
-    # get all Raster tile set assets
+    # get all raster tile set assets with the same grid.
     latest_tile_sets = await db.all(latest_raster_tile_sets, {"grid": grid})
-    # create layers
+
+    # build list of layers, including any derived layers, for all
+    # single-band rasters found
     layers: List[Layer] = []
     for row in latest_tile_sets:
         creation_options = row.creation_options

--- a/tests_v2/conftest.py
+++ b/tests_v2/conftest.py
@@ -245,6 +245,12 @@ async def generic_raster_version(
             "creation_options": RASTER_CREATION_OPTIONS,
         },
     )
+    await async_client.patch(
+        f"/dataset/{dataset_name}/{version_name}",
+        json={
+            "is_latest": True,
+        },
+    )
 
     # Set all pending tasks to success
     for job_id in batch_job_mock.jobs:

--- a/tests_v2/unit/app/routes/datasets/test_query.py
+++ b/tests_v2/unit/app/routes/datasets/test_query.py
@@ -74,6 +74,21 @@ async def test_query_dataset_with_unrestricted_api_key(
 
 
 @pytest.mark.asyncio
+async def test_fields_dataset_raster(
+    generic_raster_version, async_client: AsyncClient
+):
+    dataset_name, version_name, _ = generic_raster_version
+    response = await async_client.get(f"/dataset/{dataset_name}/{version_name}/fields")
+
+    assert response.status_code == 200
+    data = response.json()["data"]
+    assert len(data) == 2
+    assert data[0]["pixel_meaning"] == 'area__ha'
+    assert data[0]["values_table"] == None
+    assert data[1]["pixel_meaning"] == 'my_first_dataset__year'
+    assert data[1]["values_table"] == None
+
+@pytest.mark.asyncio
 async def test_query_dataset_raster_bad_get(
     generic_raster_version,
     apikey,


### PR DESCRIPTION
GTC-2443 Fix /fields query for versions with only raster assets

Uncommented and fixed some existing code. Added in the extra magic field "area__ha", as requested.

Added a test. I wasn't able to patch an asset of the generic_raster_version to have a values_table with some rows, so I wasn't able to test the values_table value. To make the test work, I made sure the generic_raster_version was marked as the latest version.
