### PR TITLE
GTC-2161 Document special fields for raster-only datasets

### DIFF
--- a/app/routes/datasets/queries.py
+++ b/app/routes/datasets/queries.py
@@ -134,13 +134,23 @@ async def query_dataset_json(
     """Execute a READ-ONLY SQL query on the given dataset version (if
     implemented) and return response in JSON format.
 
-    Adding a geostore ID to the query will apply a spatial filter to the
-    query, only returning results for features intersecting with the
-    geostore geometry. For vector datasets, this filter will not clip
-    feature geometries to the geostore boundaries. Hence any spatial
-    transformation such as area calculations will be applied on the
-    entire feature geometry, including areas outside the geostore
-    boundaries.
+    Adding a geostore ID or directly-specified geometry to the query
+    will apply a spatial filter to the query, only returning results for
+    features intersecting with the geostore geometry. For vector
+    datasets, this filter will not clip feature geometries to the
+    geostore boundaries. Hence any spatial transformation such as area
+    calculations will be applied on the entire feature geometry,
+    including areas outside the geostore boundaries.
+
+    A geostore ID or geometry must be specified for a query to a
+    raster-only dataset.
+
+    GET to /dataset/{dataset}/{version}/fields will show fields that can
+    be used in the query. For raster-only datasets, fields for other
+    raster datasets that use the same grid are listed and can be
+    referenced. There are also several "magic" fields that can be used,
+    including "area__ha", "latitude", and "longitude".
+
     """
 
     dataset, version = dataset_version

--- a/app/routes/datasets/queries.py
+++ b/app/routes/datasets/queries.py
@@ -148,8 +148,9 @@ async def query_dataset_json(
     GET to /dataset/{dataset}/{version}/fields will show fields that can
     be used in the query. For raster-only datasets, fields for other
     raster datasets that use the same grid are listed and can be
-    referenced. There are also several "magic" fields that can be used,
-    including "area__ha", "latitude", and "longitude".
+    referenced. There are also several reserved fields with special
+    meaning that can be used, including "area__ha", "latitude", and
+    "longitude".
 
     """
 

--- a/app/routes/datasets/versions.py
+++ b/app/routes/datasets/versions.py
@@ -467,8 +467,9 @@ async def _get_raster_fields(asset: ORMAsset) -> List[RasterBandMetadata]:
     fields: List[RasterBandMetadata] = []
 
     # Magic field which is the area of the region satisfying the query
-    args: Dict[str, Any] = {"pixel_meaning": "area__ha"}
-    fields.append(RasterBandMetadata(**args))
+    for magic in ["area__ha", "latitude", "longitude"]:
+        args: Dict[str, Any] = {"pixel_meaning": magic}
+        fields.append(RasterBandMetadata(**args))
 
     # Fetch all raster tile sets that have the same grid
     grid = asset.creation_options["grid"]

--- a/app/routes/datasets/versions.py
+++ b/app/routes/datasets/versions.py
@@ -466,9 +466,9 @@ async def update_metadata(
 async def _get_raster_fields(asset: ORMAsset) -> List[RasterBandMetadata]:
     fields: List[RasterBandMetadata] = []
 
-    # Magic field which is the area of the region satisfying the query
-    for magic in ["area__ha", "latitude", "longitude"]:
-        args: Dict[str, Any] = {"pixel_meaning": magic}
+    # Add in reserved fields that have special meaning.
+    for reserved_field in ["area__ha", "latitude", "longitude"]:
+        args: Dict[str, Any] = {"pixel_meaning": reserved_field}
         fields.append(RasterBandMetadata(**args))
 
     # Fetch all raster tile sets that have the same grid

--- a/tests_v2/unit/app/routes/datasets/test_query.py
+++ b/tests_v2/unit/app/routes/datasets/test_query.py
@@ -82,11 +82,15 @@ async def test_fields_dataset_raster(
 
     assert response.status_code == 200
     data = response.json()["data"]
-    assert len(data) == 2
+    assert len(data) == 4
     assert data[0]["pixel_meaning"] == 'area__ha'
     assert data[0]["values_table"] == None
-    assert data[1]["pixel_meaning"] == 'my_first_dataset__year'
+    assert data[1]["pixel_meaning"] == 'latitude'
     assert data[1]["values_table"] == None
+    assert data[2]["pixel_meaning"] == 'longitude'
+    assert data[2]["values_table"] == None
+    assert data[3]["pixel_meaning"] == 'my_first_dataset__year'
+    assert data[3]["values_table"] == None
 
 @pytest.mark.asyncio
 async def test_query_dataset_raster_bad_get(


### PR DESCRIPTION
GTC-2161 Document special fields for raster-only datasets

Improve the documentation for query of raster-only datasets. In particular, mention that the special fields 'area__ha', 'latitude', and 'longitude' can be used and that a geometry must be specified for raster-only datasets.

Also, now that we know that 'latitude' and 'longitude' can be used for all raster-only datasets, add them to the actual /fields query (along with 'area__ha', which I added in a previous commit).

