### PR TITLE
GTC-2576 Restrict queries on licensed WDPA dataset

### DIFF
--- a/app/authentication/token.py
+++ b/app/authentication/token.py
@@ -28,6 +28,8 @@ async def is_service_account(token: str = Depends(oauth2_scheme)) -> bool:
         return True
 
 
+# Check is the authorized user is an admin. Return true if so, throw
+# an exception if not.
 async def is_admin(token: str = Depends(oauth2_scheme)) -> bool:
     """Calls GFW API to authorize user.
 
@@ -42,6 +44,25 @@ async def is_admin(token: str = Depends(oauth2_scheme)) -> bool:
     ):
         logger.warning(f"ADMIN privileges required. Unauthorized user: {response.text}")
         raise HTTPException(status_code=401, detail="Unauthorized")
+    else:
+        return True
+
+# Check is the authorized user is an admin. Return true if so, false if not (with no
+# exception).
+async def is_admin_no_exception(token: str = Depends(oauth2_scheme)) -> bool:
+    """Calls GFW API to authorize user.
+
+    User must be ADMIN for gfw app
+    """
+
+    response: Response = await who_am_i(token)
+
+    if response.status_code == 401 or not (
+        response.json()["role"] == "ADMIN"
+        and "gfw" in response.json()["extraUserData"]["apps"]
+    ):
+        logger.warning(f"ADMIN privileges required. Unauthorized user: {response.text}")
+        return False
     else:
         return True
 

--- a/app/routes/datasets/queries.py
+++ b/app/routes/datasets/queries.py
@@ -88,7 +88,7 @@ AREA_DENSITY_RASTER_SUFFIXES = ["_ha-1", "_ha_yr-1"]
 
 # Datasets that require admin privileges to do a query. (Extra protection on
 # commercial datasets which shouldn't be downloaded in any way.)
-PROTECTED_QUERY_DATASETS = ["licensed_wdpa_protected_areas"]
+PROTECTED_QUERY_DATASETS = ["wdpa_licensed_protected_areas"]
 
 @router.get(
     "/{dataset}/{version}/query",

--- a/app/routes/datasets/queries.py
+++ b/app/routes/datasets/queries.py
@@ -23,7 +23,7 @@ from pglast.printer import RawStream
 from pydantic.tools import parse_obj_as
 from sqlalchemy.sql import and_
 
-from ...authentication.token import is_admin_no_exception
+from ...authentication.token import is_gfwpro_admin
 from ...application import db
 
 # from ...authentication.api_keys import get_api_key
@@ -161,9 +161,7 @@ async def query_dataset_json(
 
     dataset, version = dataset_version
     if dataset in PROTECTED_QUERY_DATASETS:
-        is_authorized = await is_admin_no_exception()
-        if not is_authorized:
-            raise HTTPException(status_code=401, detail="Unauthorized")
+        await is_gfwpro_admin(error_str="Unauthorized query on a restricted dataset")
 
     if geostore_id:
         geostore: Optional[GeostoreCommon] = await get_geostore(

--- a/tests_v2/conftest.py
+++ b/tests_v2/conftest.py
@@ -300,7 +300,7 @@ async def licensed_dataset(
     """Create licensed dataset."""
 
     # Create dataset
-    dataset_name: str = "licensed_wdpa_protected_areas"
+    dataset_name: str = "wdpa_licensed_protected_areas"
 
     await async_client.put(
         f"/dataset/{dataset_name}", json={"metadata": DATASET_METADATA}

--- a/tests_v2/unit/app/routes/datasets/test_query.py
+++ b/tests_v2/unit/app/routes/datasets/test_query.py
@@ -445,7 +445,7 @@ async def test_query_licensed_disallowed_11(
     )
     assert response.status_code == 401
     assert response.json()["message"] == (
-        "Unauthorized"
+        "Unauthorized query on a restricted dataset"
     )
 
 @pytest.mark.asyncio

--- a/tests_v2/unit/app/routes/datasets/test_query.py
+++ b/tests_v2/unit/app/routes/datasets/test_query.py
@@ -433,6 +433,20 @@ async def test_query_vector_asset_disallowed_10(
         "You might need to add explicit type casts."
     )
 
+@pytest.mark.asyncio()
+async def test_query_licensed_disallowed_11(
+        licensed_version, async_client: AsyncClient
+):
+    dataset, version, _ = licensed_version
+
+    response = await async_client.get(
+        f"/dataset/{dataset}/{version}/query?sql=select(*) from mytable;",
+        follow_redirects=True,
+    )
+    assert response.status_code == 401
+    assert response.json()["message"] == (
+        "Unauthorized"
+    )
 
 @pytest.mark.asyncio
 @pytest.mark.skip("Temporarily skip while _get_data_environment is being cached")


### PR DESCRIPTION
GTC-2576 Restrict queries on licensed WDPA dataset

Only allow queries to versions of the licensed WDPA dataset for admin users (i.e. a bearer token is provided that signifies an admin user).

For now, we just have a simple list of restricted datasets in the code, rather than adding some new dataset attribute.

Added a test licensed dataset/version and added a test that the query is restricted of a licensed version.

