### PR TITLE
Gtc-2194: Dont log Batch job envs (which include creds)

### DIFF
--- a/app/tasks/batch.py
+++ b/app/tasks/batch.py
@@ -129,7 +129,7 @@ def submit_batch_job(
             "command": job.command,
             "vcpus": job.vcpus,
             "memory": job.memory,
-            "environment": job.environment,
+            "environment": "<redacted>",
         },
         "retryStrategy": {
             "attempts": job.attempts,
@@ -151,6 +151,8 @@ def submit_batch_job(
     }
 
     logger.info(f"Submitting batch job with payload: {payload}")
+
+    payload["containerOverrides"]["environment"] = job.environment
 
     response = client.submit_job(**payload)
 

--- a/tests_v2/conftest.py
+++ b/tests_v2/conftest.py
@@ -2,6 +2,7 @@ import json
 import os
 from datetime import datetime
 from typing import Any, AsyncGenerator, Dict, Tuple
+from uuid import UUID
 
 import pytest
 import pytest_asyncio
@@ -161,7 +162,9 @@ async def generic_vector_source_version(
     dataset_name, _ = generic_dataset
     version_name: str = "v1"
 
-    await create_vector_source_version(async_client, dataset_name, version_name, monkeypatch)
+    await create_vector_source_version(
+        async_client, dataset_name, version_name, monkeypatch
+    )
 
     # yield version
     yield dataset_name, version_name, VERSION_METADATA
@@ -228,6 +231,7 @@ async def create_vector_source_version(
     response = await async_client.get(f"/dataset/{dataset_name}/{version_name}")
     assert response.json()["data"]["status"] == "saved"
 
+
 @pytest_asyncio.fixture
 async def generic_raster_version(
     async_client: AsyncClient,
@@ -293,6 +297,7 @@ async def generic_raster_version(
     # clean up
     await async_client.delete(f"/dataset/{dataset_name}/{version_name}")
 
+
 @pytest_asyncio.fixture
 async def licensed_dataset(
     async_client: AsyncClient,
@@ -312,6 +317,7 @@ async def licensed_dataset(
     # Clean up
     await async_client.delete(f"/dataset/{dataset_name}")
 
+
 @pytest_asyncio.fixture
 async def licensed_version(
     async_client: AsyncClient,
@@ -323,13 +329,16 @@ async def licensed_version(
     dataset_name, _ = licensed_dataset
     version_name: str = "v1"
 
-    await create_vector_source_version(async_client, dataset_name, version_name, monkeypatch)
+    await create_vector_source_version(
+        async_client, dataset_name, version_name, monkeypatch
+    )
 
     # yield version
     yield dataset_name, version_name, VERSION_METADATA
 
     # clean up
     await async_client.delete(f"/dataset/{dataset_name}/{version_name}")
+
 
 @pytest_asyncio.fixture
 async def apikey(
@@ -451,3 +460,10 @@ async def _create_geostore(geojson: Dict[str, Any], async_client: AsyncClient) -
     assert response.status_code == 201
 
     return response.json()["data"]["gfw_geostore_id"]
+
+
+async def mock_callback(task_id: UUID, change_log: ChangeLog):
+    async def dummy_function():
+        pass
+
+    return dummy_function

--- a/tests_v2/unit/app/tasks/test_batch.py
+++ b/tests_v2/unit/app/tasks/test_batch.py
@@ -1,0 +1,50 @@
+import asyncio
+from typing import Any, Coroutine, Dict, List
+from unittest.mock import MagicMock, patch
+from uuid import UUID
+
+from fastapi.logger import logger
+
+from app.models.pydantic.change_log import ChangeLog
+from app.tasks.batch import submit_batch_job
+from app.tasks.vector_source_assets import _create_add_gfw_fields_job
+
+TEST_JOB_ENV: List[Dict[str, str]] = [{"name": "PASSWORD", "value": "DON'T LOG ME"}]
+
+
+async def mock_callback(uuid: UUID, changelog: ChangeLog):
+    async def helper_function() -> Coroutine[Any, Any, None]:
+        # Simulate some asynchronous work
+        return asyncio.sleep(0)
+
+    return helper_function()
+
+
+@patch("app.utils.aws.boto3.client")
+@patch.object(logger, "info")  # Patch the logger.info directly
+@patch("app.tasks.batch.UUID")  # Patch the UUID class
+async def test_submit_batch_job(mock_uuid, mock_logging_info, mock_boto3_client):
+    mock_client = MagicMock()
+    mock_boto3_client.return_value = mock_client
+
+    attempt_duration_seconds: int = 100
+
+    job = await _create_add_gfw_fields_job(
+        "some_dataset",
+        "v1",
+        parents=list(),
+        job_env=TEST_JOB_ENV,
+        callback=mock_callback,
+        attempt_duration_seconds=attempt_duration_seconds,
+    )
+
+    # Call the function you want to test
+    submit_batch_job(job)
+
+    mock_boto3_client.assert_called_once_with(
+        "batch", region_name="us-east-1", endpoint_url=None
+    )
+
+    # Assert that the logger.info was called with the expected log message
+    assert "add_gfw_fields" in mock_logging_info.call_args.args[0]
+    assert "DON'T LOG ME" not in mock_logging_info.call_args.args[0]

--- a/tests_v2/unit/app/tasks/test_batch.py
+++ b/tests_v2/unit/app/tasks/test_batch.py
@@ -1,23 +1,13 @@
-import asyncio
-from typing import Any, Coroutine, Dict, List
+from typing import Dict, List
 from unittest.mock import MagicMock, patch
-from uuid import UUID
 
 from fastapi.logger import logger
 
-from app.models.pydantic.change_log import ChangeLog
 from app.tasks.batch import submit_batch_job
 from app.tasks.vector_source_assets import _create_add_gfw_fields_job
+from tests_v2.conftest import mock_callback
 
 TEST_JOB_ENV: List[Dict[str, str]] = [{"name": "PASSWORD", "value": "DON'T LOG ME"}]
-
-
-async def mock_callback(uuid: UUID, changelog: ChangeLog):
-    async def helper_function() -> Coroutine[Any, Any, None]:
-        # Simulate some asynchronous work
-        return asyncio.sleep(0)
-
-    return helper_function()
 
 
 @patch("app.utils.aws.boto3.client")

--- a/tests_v2/unit/app/tasks/test_vector_source_assets.py
+++ b/tests_v2/unit/app/tasks/test_vector_source_assets.py
@@ -16,6 +16,7 @@ from app.tasks.vector_source_assets import (
     append_vector_source_asset,
     vector_source_asset,
 )
+from tests_v2.conftest import mock_callback
 
 MODULE_PATH_UNDER_TEST = "app.tasks.vector_source_assets"
 
@@ -38,14 +39,6 @@ CREATION_OPTIONS = {
     "indices": [],
 }
 VECTOR_ASSET_UUID = UUID("1b368160-caf8-2bd7-819a-ad4949361f02")
-
-
-async def dummy_function():
-    pass
-
-
-async def mock_callback(task_id: UUID, change_log: ChangeLog):
-    return dummy_function
 
 
 class TestVectorSourceAssetsHelpers:


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [x] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When a Batch job is spun off by the data API it logs the job's environment, which includes a bunch of credentials.

Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- I made it so that the credentials are added to the job info only after logging.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
