### PR TITLE
Disable wdpa_licensed_protected_area query permission check

### DIFF
--- a/app/routes/datasets/queries.py
+++ b/app/routes/datasets/queries.py
@@ -160,8 +160,8 @@ async def query_dataset_json(
     """
 
     dataset, version = dataset_version
-    if dataset in PROTECTED_QUERY_DATASETS:
-        await is_gfwpro_admin(error_str="Unauthorized query on a restricted dataset")
+    #if dataset in PROTECTED_QUERY_DATASETS:
+    #    await is_gfwpro_admin(error_str="Unauthorized query on a restricted dataset")
 
     if geostore_id:
         geostore: Optional[GeostoreCommon] = await get_geostore(

--- a/tests_v2/unit/app/routes/datasets/test_query.py
+++ b/tests_v2/unit/app/routes/datasets/test_query.py
@@ -434,6 +434,7 @@ async def test_query_vector_asset_disallowed_10(
     )
 
 @pytest.mark.asyncio()
+@pytest.mark.skip("Skip while figuring out permissions")
 async def test_query_licensed_disallowed_11(
         licensed_version, async_client: AsyncClient
 ):


### PR DESCRIPTION
Disable wdpa_licensed_protected_area query permission check

This doesn't seem to be working anymore - it is causing a permission error, even for admins with the gfw-pro app.

So, I'm disabling this check temporarily until we figure out to how to make it work.
