### PR TITLE
GTC-2576 Restrict queries on licensed WDPA dataset (2nd try)

### DIFF
--- a/app/authentication/token.py
+++ b/app/authentication/token.py
@@ -51,7 +51,7 @@ async def is_gfwpro_admin_for_query(dataset: str = Depends(dataset_dependency),
         if token == None:
             raise HTTPException(status_code=401, detail="Unauthorized query on a restricted dataset")
         else:
-            await is_app_admin(cast(str, token), "gfw-pro",
+            return await is_app_admin(cast(str, token), "gfw-pro",
                                error_str="Unauthorized query on a restricted dataset")
 
     return True

--- a/app/authentication/token.py
+++ b/app/authentication/token.py
@@ -1,13 +1,21 @@
-from typing import Tuple
+from typing import Tuple, cast
 
 from fastapi import Depends, HTTPException
 from fastapi.logger import logger
 from fastapi.security import OAuth2PasswordBearer
 from httpx import Response
+from ..routes import dataset_dependency
 
 from ..utils.rw_api import who_am_i
 
+# token dependency where we immediately cause an exception if there is no auth token
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/token")
+# token dependency where we don't cause exception if there is no auth token
+oauth2_scheme_no_auto = OAuth2PasswordBearer(tokenUrl="/token", auto_error=False)
+
+# Datasets that require admin privileges to do a query. (Extra protection on
+# commercial datasets which shouldn't be downloaded in any way.)
+PROTECTED_QUERY_DATASETS = ["wdpa_licensed_protected_areas"]
 
 
 async def is_service_account(token: str = Depends(oauth2_scheme)) -> bool:
@@ -36,13 +44,21 @@ async def is_admin(token: str = Depends(oauth2_scheme)) -> bool:
 
     return await is_app_admin(token, "gfw", "Unauthorized")
 
-async def is_gfwpro_admin(error_str: str, token: str = Depends(oauth2_scheme)) -> bool:
-    """Calls GFW API to authorize user.
-
-    User must be ADMIN for gfw pro app
+async def is_gfwpro_admin_for_query(dataset: str = Depends(dataset_dependency),
+                                    token: str | None = Depends(oauth2_scheme_no_auto)) -> bool:
+    """If the dataset is protected dataset, calls GFW API to authorize user by
+    requiring the user must be ADMIN for gfw-pro app.  If the dataset is not
+    protected, just returns True without any required token or authorization.
     """
+    
+    if dataset in PROTECTED_QUERY_DATASETS:
+        if token == None:
+            raise HTTPException(status_code=401, detail="Unauthorized query on a restricted dataset")
+        else:
+            await is_app_admin(cast(str, token), "gfw-pro",
+                               error_str="Unauthorized query on a restricted dataset")
 
-    return await is_app_admin(token, "gfw-pro", error_str)
+    return True
 
 async def is_app_admin(token: str, app: str, error_str: str) -> bool:
     """Calls GFW API to authorize user.

--- a/app/authentication/token.py
+++ b/app/authentication/token.py
@@ -7,16 +7,12 @@ from httpx import Response
 from ..routes import dataset_dependency
 
 from ..utils.rw_api import who_am_i
+from ..settings.globals import PROTECTED_QUERY_DATASETS
 
 # token dependency where we immediately cause an exception if there is no auth token
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/token")
 # token dependency where we don't cause exception if there is no auth token
 oauth2_scheme_no_auto = OAuth2PasswordBearer(tokenUrl="/token", auto_error=False)
-
-# Datasets that require admin privileges to do a query. (Extra protection on
-# commercial datasets which shouldn't be downloaded in any way.)
-PROTECTED_QUERY_DATASETS = ["wdpa_licensed_protected_areas"]
-
 
 async def is_service_account(token: str = Depends(oauth2_scheme)) -> bool:
     """Calls GFW API to authorize user.

--- a/app/routes/datasets/queries.py
+++ b/app/routes/datasets/queries.py
@@ -131,6 +131,7 @@ async def query_dataset_json(
         GeostoreOrigin.gfw, description="Service to search first for geostore."
     ),
     is_authorized: bool = Depends(is_gfwpro_admin_for_query),
+    # api_key: APIKey = Depends(get_api_key),
 ):
     """Execute a READ-ONLY SQL query on the given dataset version (if
     implemented) and return response in JSON format.
@@ -192,6 +193,7 @@ async def query_dataset_csv(
         Delimiters.comma, description="Delimiter to use for CSV file."
     ),
     is_authorized: bool = Depends(is_gfwpro_admin_for_query),
+    # api_key: APIKey = Depends(get_api_key),
 ):
     """Execute a READ-ONLY SQL query on the given dataset version (if
     implemented) and return response in CSV format.
@@ -254,6 +256,7 @@ async def query_dataset_json_post(
     dataset_version: Tuple[str, str] = Depends(dataset_version_dependency),
     request: QueryRequestIn,
     is_authorized: bool = Depends(is_gfwpro_admin_for_query),
+    # api_key: APIKey = Depends(get_api_key),
 ):
     """Execute a READ-ONLY SQL query on the given dataset version (if
     implemented)."""
@@ -284,6 +287,7 @@ async def query_dataset_csv_post(
     dataset_version: Tuple[str, str] = Depends(dataset_version_dependency),
     request: CsvQueryRequestIn,
     is_authorized: bool = Depends(is_gfwpro_admin_for_query),
+    # api_key: APIKey = Depends(get_api_key),
 ):
     """Execute a READ-ONLY SQL query on the given dataset version (if
     implemented)."""

--- a/app/routes/datasets/queries.py
+++ b/app/routes/datasets/queries.py
@@ -23,7 +23,7 @@ from pglast.printer import RawStream
 from pydantic.tools import parse_obj_as
 from sqlalchemy.sql import and_
 
-from ...authentication.token import is_gfwpro_admin
+from ...authentication.token import is_gfwpro_admin_for_query
 from ...application import db
 
 # from ...authentication.api_keys import get_api_key
@@ -86,10 +86,6 @@ router = APIRouter()
 # Special suffixes to do an extra area density calculation on the raster data set.
 AREA_DENSITY_RASTER_SUFFIXES = ["_ha-1", "_ha_yr-1"]
 
-# Datasets that require admin privileges to do a query. (Extra protection on
-# commercial datasets which shouldn't be downloaded in any way.)
-PROTECTED_QUERY_DATASETS = ["wdpa_licensed_protected_areas"]
-
 @router.get(
     "/{dataset}/{version}/query",
     response_class=RedirectResponse,
@@ -134,7 +130,7 @@ async def query_dataset_json(
     geostore_origin: GeostoreOrigin = Query(
         GeostoreOrigin.gfw, description="Service to search first for geostore."
     ),
-    # api_key: APIKey = Depends(get_api_key),
+    is_authorized: bool = Depends(is_gfwpro_admin_for_query),
 ):
     """Execute a READ-ONLY SQL query on the given dataset version (if
     implemented) and return response in JSON format.
@@ -160,8 +156,6 @@ async def query_dataset_json(
     """
 
     dataset, version = dataset_version
-    #if dataset in PROTECTED_QUERY_DATASETS:
-    #    await is_gfwpro_admin(error_str="Unauthorized query on a restricted dataset")
 
     if geostore_id:
         geostore: Optional[GeostoreCommon] = await get_geostore(
@@ -197,7 +191,7 @@ async def query_dataset_csv(
     delimiter: Delimiters = Query(
         Delimiters.comma, description="Delimiter to use for CSV file."
     ),
-    # api_key: APIKey = Depends(get_api_key),
+    is_authorized: bool = Depends(is_gfwpro_admin_for_query),
 ):
     """Execute a READ-ONLY SQL query on the given dataset version (if
     implemented) and return response in CSV format.
@@ -259,7 +253,7 @@ async def query_dataset_json_post(
     *,
     dataset_version: Tuple[str, str] = Depends(dataset_version_dependency),
     request: QueryRequestIn,
-    # api_key: APIKey = Depends(get_api_key),
+    is_authorized: bool = Depends(is_gfwpro_admin_for_query),
 ):
     """Execute a READ-ONLY SQL query on the given dataset version (if
     implemented)."""
@@ -289,7 +283,7 @@ async def query_dataset_csv_post(
     *,
     dataset_version: Tuple[str, str] = Depends(dataset_version_dependency),
     request: CsvQueryRequestIn,
-    # api_key: APIKey = Depends(get_api_key),
+    is_authorized: bool = Depends(is_gfwpro_admin_for_query),
 ):
     """Execute a READ-ONLY SQL query on the given dataset version (if
     implemented)."""

--- a/app/settings/globals.py
+++ b/app/settings/globals.py
@@ -185,3 +185,7 @@ INTERNAL_DOMAINS = config("INTERNAL_DOMAINS", cast=str, default=default_domains)
 GOOGLE_APPLICATION_CREDENTIALS = config(
     "GOOGLE_APPLICATION_CREDENTIALS", cast=str, default="/root/.gcs/private_key.json"
 )
+
+# Datasets that require admin privileges to do a query. (Extra protection on
+# commercial datasets which shouldn't be downloaded in any way.)
+PROTECTED_QUERY_DATASETS = ["wdpa_licensed_protected_areas"]

--- a/tests_v2/unit/app/routes/datasets/test_query.py
+++ b/tests_v2/unit/app/routes/datasets/test_query.py
@@ -434,7 +434,6 @@ async def test_query_vector_asset_disallowed_10(
     )
 
 @pytest.mark.asyncio()
-@pytest.mark.skip("Skip while figuring out permissions")
 async def test_query_licensed_disallowed_11(
         licensed_version, async_client: AsyncClient
 ):


### PR DESCRIPTION
Make the protection correct, now that I understand FastAPI and its dependencies better. The checking for whether the dataset is protected must occur within a dependency function, since only a dependency function for a path handler has access to the bearer token and the dataset name.

Added in protection for GET query/json, GET query/csv, and their less-used POST equivalents.
