### PR TITLE
GTC-2706 Give error code and message when asset UID is wrong

### DIFF
--- a/app/tasks/raster_tile_cache_assets/raster_tile_cache_assets.py
+++ b/app/tasks/raster_tile_cache_assets/raster_tile_cache_assets.py
@@ -4,6 +4,7 @@ from uuid import UUID
 import numpy as np
 from fastapi import HTTPException
 from fastapi.logger import logger
+from asyncpg import DataError
 
 from app.crud.assets import get_asset
 from app.models.enum.assets import AssetType
@@ -29,6 +30,7 @@ from app.tasks.raster_tile_cache_assets.utils import (
 )
 from app.utils.path import get_asset_uri, tile_uri_to_tiles_geojson
 
+from ...errors import RecordNotFoundError
 
 async def raster_tile_cache_asset(
     dataset: str,
@@ -204,9 +206,15 @@ async def raster_tile_cache_validator(
     Used in asset route. If validation fails, it will raise an
     HTTPException visible to user.
     """
-    source_asset: ORMAsset = await get_asset(
-        input_data["creation_options"]["source_asset_id"]
-    )
+    try:
+        source_asset: ORMAsset = await get_asset(
+            input_data["creation_options"]["source_asset_id"]
+        )
+    except RecordNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    except DataError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    
     if (source_asset.dataset != dataset) or (source_asset.version != version):
         message: str = (
             "Dataset and version of source asset must match dataset and "


### PR DESCRIPTION
GTC-2706 Give error code and message when asset UID is wrong

If the asset uid when creating a raster tile cache is wrong (bad format or nonexistent), return a better status code and error message, rather than just a 500 (internal system error)

Added new test in test_assets.py for error cases when the source asset uid does not exist. I factored out a new function for creating the default asset to reduce a bunch of duplicated code.

Also, the test test_raster_tile_cache_asset had been completely disabled for quite a while. I re-enabled the first 4 sub-tests, which work fine. The fifth sub-test does not work, so I left it disabled and filed issue GTC-2735.
