### PR TITLE
GTC-2649 Include asset_id in the version get endpoint

### DIFF
--- a/app/models/pydantic/versions.py
+++ b/app/models/pydantic/versions.py
@@ -17,7 +17,8 @@ class Version(BaseRecord):
     metadata: Union[VersionMetadataOut, BaseModel]
     status: VersionStatus = VersionStatus.pending
 
-    assets: List[Tuple[str, str]] = list()
+    # Each element of assets is a tuple (asset_type, assert_uri, asset_id)
+    assets: List[Tuple[str, str, str]] = list()
 
 
 class VersionCreateIn(StrictBaseModel):

--- a/app/routes/datasets/versions.py
+++ b/app/routes/datasets/versions.py
@@ -500,14 +500,14 @@ async def _version_response(
     associated assets."""
 
     assets: List[ORMAsset] = (
-        await ORMAsset.select("asset_type", "asset_uri")
+        await ORMAsset.select("asset_type", "asset_uri", "asset_id")
         .where(ORMAsset.dataset == dataset)
         .where(ORMAsset.version == version)
         .where(ORMAsset.status == AssetStatus.saved)
         .gino.all()
     )
     data = Version.from_orm(data).dict(by_alias=True)
-    data["assets"] = [(asset[0], asset[1]) for asset in assets]
+    data["assets"] = [(asset[0], asset[1], str(asset[2])) for asset in assets]
 
     return VersionResponse(data=Version(**data))
 

--- a/tests_v2/unit/app/routes/datasets/test_version.py
+++ b/tests_v2/unit/app/routes/datasets/test_version.py
@@ -1,6 +1,7 @@
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
 from httpx import AsyncClient
+import re
 
 from app.routes.datasets import versions
 from app.tasks import batch
@@ -17,6 +18,14 @@ async def test_get_version(async_client: AsyncClient, generic_vector_source_vers
     assert resp.status_code == 200
     data = resp.json()
     assert_jsend(data)
+    first_asset = data["data"]["assets"][0]
+    assert len(first_asset) == 3
+    assert first_asset[0] == "Geo database table"
+    # Check asset_id looks reasonable
+    asset_id = first_asset[2]
+    assert len(asset_id) > 30
+    pattern = re.compile(r'^[a-zA-Z0-9-]+$')
+    assert bool(pattern.match(asset_id))
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x ] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [ x] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [ x] Check the commit's or even all commits' message styles matches our requested structure.
- [ x] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
The Get version endpoint currently returns a list of all the assets, where for each asset, a pair of (asset_type, asset_uri) are provided.

Issue Number: GTC-2649


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

With this change, the get version endpoint also provides the asset_id for each asset, which is very useful for immediately jumping to the information for a particular asset.

## Does this introduce a breaking change?

- [ x] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
This does change the API, so it is a slightly breaking change.  But it is just taking one extra element on to the information for each asset.  And it is unlikely people are parsing information about individual assets - almost all requests are about specific assets that have already been determined.

## Other information

I believe it is fine to modify Version. In some cases (like add_new_version) where a new asset is being created in the background, the _version_response may have an asset with an empty asset_id, but this seems to be all fine (all tests pass). But let me know if you think I should leave Version unmodified and create a separate type only for the output of get_inversion that includes the asset_id.

