### PR TITLE
GTC-2649 Include asset_id in the version get endpoint

### DIFF
--- a/app/models/pydantic/versions.py
+++ b/app/models/pydantic/versions.py
@@ -17,7 +17,8 @@ class Version(BaseRecord):
     metadata: Union[VersionMetadataOut, BaseModel]
     status: VersionStatus = VersionStatus.pending
 
-    assets: List[Tuple[str, str]] = list()
+    # Each element of assets is a tuple (asset_type, assert_uri, asset_id)
+    assets: List[Tuple[str, str, str]] = list()
 
 
 class VersionCreateIn(StrictBaseModel):

--- a/app/routes/datasets/versions.py
+++ b/app/routes/datasets/versions.py
@@ -500,14 +500,14 @@ async def _version_response(
     associated assets."""
 
     assets: List[ORMAsset] = (
-        await ORMAsset.select("asset_type", "asset_uri")
+        await ORMAsset.select("asset_type", "asset_uri", "asset_id")
         .where(ORMAsset.dataset == dataset)
         .where(ORMAsset.version == version)
         .where(ORMAsset.status == AssetStatus.saved)
         .gino.all()
     )
     data = Version.from_orm(data).dict(by_alias=True)
-    data["assets"] = [(asset[0], asset[1]) for asset in assets]
+    data["assets"] = [(asset[0], asset[1], str(asset[2])) for asset in assets]
 
     return VersionResponse(data=Version(**data))
 

--- a/tests_v2/unit/app/routes/datasets/test_version.py
+++ b/tests_v2/unit/app/routes/datasets/test_version.py
@@ -1,6 +1,7 @@
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
 from httpx import AsyncClient
+import re
 
 from app.routes.datasets import versions
 from app.tasks import batch
@@ -17,6 +18,14 @@ async def test_get_version(async_client: AsyncClient, generic_vector_source_vers
     assert resp.status_code == 200
     data = resp.json()
     assert_jsend(data)
+    first_asset = data["data"]["assets"][0]
+    assert len(first_asset) == 3
+    assert first_asset[0] == "Geo database table"
+    # Check asset_id looks reasonable
+    asset_id = first_asset[2]
+    assert len(asset_id) > 30
+    pattern = re.compile(r'^[a-zA-Z0-9-]+$')
+    assert bool(pattern.match(asset_id))
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
GTC-2649 Include asset_id in the version get endpoint

The version get endpoint already includes asset_type and asset_uri, but it would be more useful if it also included the associated asset_id.

This change has been tested on staging.  This is just moving the PR from develop to master.  (There are other changes on develop that may not be ready to go up yet, so just doing a PR for this change only).
