### PR TITLE
GTC-2449 Catch access denied error in get_aws_files()

### DIFF
--- a/app/routes/datasets/versions.py
+++ b/app/routes/datasets/versions.py
@@ -560,7 +560,7 @@ def _verify_source_file_access(sources: List[str]) -> None:
         raise HTTPException(
             status_code=400,
             detail=(
-                "Cannot access all of the source files. "
+                "Cannot access all of the source files (non-existent or access denied). "
                 f"Invalid sources: {invalid_sources}"
             ),
         )

--- a/tests/routes/datasets/test_versions.py
+++ b/tests/routes/datasets/test_versions.py
@@ -310,7 +310,7 @@ async def test_invalid_source_uri(async_client: AsyncClient):
     assert response.json()["status"] == "failed"
     assert (
         response.json()["message"]
-        == f"Cannot access all of the source files. Invalid sources: ['{bad_uri}']"
+        == f"Cannot access all of the source files (non-existent or access denied). Invalid sources: ['{bad_uri}']"
     )
 
     # Create a version with a valid source_uri so we have something to append to
@@ -332,7 +332,7 @@ async def test_invalid_source_uri(async_client: AsyncClient):
     assert response.json()["status"] == "failed"
     assert (
         response.json()["message"]
-        == f"Cannot access all of the source files. Invalid sources: ['{bad_uri}']"
+        == f"Cannot access all of the source files (non-existent or access denied). Invalid sources: ['{bad_uri}']"
     )
 
     # Test appending to a version that DOESN'T exist


### PR DESCRIPTION
GTC-2449 Catch access denied error in get_aws_files()

Currently, we are only catching NoSuchBucket errors, but there can also be AccessDenied errors. If an 'access denied' happens, we get an uncaught exception, which gives an internal server error. Strangely, s3_client.exceptions doesn't have AccessDenied, so we just catch all botocore exceptions (which is probably what we should do anyway).

I couldn't create any new test to emulate access denied, so will just test it out in staging.
