### PR TITLE
Cache _get_data_env results for 5 minutes

### DIFF
--- a/app/routes/datasets/queries.py
+++ b/app/routes/datasets/queries.py
@@ -7,13 +7,13 @@ from urllib.parse import unquote
 from uuid import UUID, uuid4
 
 import httpx
+from async_lru import alru_cache
 from asyncpg import DataError, InsufficientPrivilegeError, SyntaxOrAccessError
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi import Request as FastApiRequest
 from fastapi import Response as FastApiResponse
 from fastapi.encoders import jsonable_encoder
 from fastapi.logger import logger
-
 # from fastapi.openapi.models import APIKey
 from fastapi.responses import RedirectResponse
 from pglast import printers  # noqa
@@ -21,11 +21,9 @@ from pglast import Node, parse_sql
 from pglast.parser import ParseError
 from pglast.printer import RawStream
 from pydantic.tools import parse_obj_as
-from sqlalchemy.sql import and_
 
 from ...authentication.token import is_gfwpro_admin_for_query
 from ...application import db
-
 # from ...authentication.api_keys import get_api_key
 from ...crud import assets
 from ...models.enum.assets import AssetType
@@ -62,7 +60,6 @@ from ...models.enum.pixetl import Grid
 from ...models.enum.queries import QueryFormat, QueryType
 from ...models.orm.assets import Asset as AssetORM
 from ...models.orm.queries.raster_assets import latest_raster_tile_sets
-from ...models.orm.versions import Version as VersionORM
 from ...models.pydantic.asset_metadata import RasterTable, RasterTableRow
 from ...models.pydantic.creation_options import NoDataType
 from ...models.pydantic.geostore import Geometry, GeostoreCommon
@@ -659,12 +656,13 @@ async def _query_raster_lambda(
 
 
 def _get_area_density_name(nm):
-    """Return empty string if nm doesn't not have an area-density suffix, else
+    """Return empty string if nm doesn't have an area-density suffix, else
     return nm with the area-density suffix removed."""
     for suffix in AREA_DENSITY_RASTER_SUFFIXES:
         if nm.endswith(suffix):
             return nm[:-len(suffix)]
     return ""
+
 
 def _get_default_layer(dataset, pixel_meaning):
     default_type = pixel_meaning
@@ -683,6 +681,7 @@ def _get_default_layer(dataset, pixel_meaning):
         return f"{dataset}__{default_type}"
 
 
+@alru_cache(maxsize=16, ttl=300.0)
 async def _get_data_environment(grid: Grid) -> DataEnvironment:
     # get all raster tile set assets with the same grid.
     latest_tile_sets = await db.all(latest_raster_tile_sets, {"grid": grid})

--- a/tests_v2/conftest.py
+++ b/tests_v2/conftest.py
@@ -93,32 +93,6 @@ async def async_client(db, init_db) -> AsyncGenerator[AsyncClient, None]:
     app.dependency_overrides = {}
 
 
-@pytest_asyncio.fixture(scope="function")
-async def async_client_per_function(db, init_db) -> AsyncGenerator[AsyncClient, None]:
-    """Async Test Client that's limited to per-function scope.
-    Use sparingly (such as when you need to clear caches) to avoid lengthier tests
-    """
-    from app.main import app
-
-    # mock authentication function to avoid having to reach out to RW API during tests
-    app.dependency_overrides[is_admin] = bool_function_closure(True, with_args=False)
-    app.dependency_overrides[is_service_account] = bool_function_closure(
-        True, with_args=False
-    )
-    app.dependency_overrides[get_user] = get_admin_mocked
-
-    async with AsyncClient(
-        app=app,
-        base_url="http://test",
-        trust_env=False,
-        headers={"Origin": "https://www.globalforestwatch.org"},
-    ) as client:
-        yield client
-
-    # Clean up
-    app.dependency_overrides = {}
-
-
 @pytest_asyncio.fixture
 async def async_client_unauthenticated(
     db, init_db

--- a/tests_v2/conftest.py
+++ b/tests_v2/conftest.py
@@ -93,6 +93,12 @@ async def async_client(db, init_db) -> AsyncGenerator[AsyncClient, None]:
     app.dependency_overrides = {}
 
 
+@pytest_asyncio.fixture(scope="function")
+async def async_client_per_function(async_client) -> AsyncGenerator[AsyncClient, None]:
+    """Async Test Client that's limited to per-function scope."""
+    yield async_client
+
+
 @pytest_asyncio.fixture
 async def async_client_unauthenticated(
     db, init_db

--- a/tests_v2/conftest.py
+++ b/tests_v2/conftest.py
@@ -96,7 +96,25 @@ async def async_client(db, init_db) -> AsyncGenerator[AsyncClient, None]:
 @pytest_asyncio.fixture(scope="function")
 async def async_client_per_function(async_client) -> AsyncGenerator[AsyncClient, None]:
     """Async Test Client that's limited to per-function scope."""
-    yield async_client
+    from app.main import app
+
+    # mock authentication function to avoid having to reach out to RW API during tests
+    app.dependency_overrides[is_admin] = bool_function_closure(True, with_args=False)
+    app.dependency_overrides[is_service_account] = bool_function_closure(
+        True, with_args=False
+    )
+    app.dependency_overrides[get_user] = get_admin_mocked
+
+    async with AsyncClient(
+        app=app,
+        base_url="http://test",
+        trust_env=False,
+        headers={"Origin": "https://www.globalforestwatch.org"},
+    ) as client:
+        yield client
+
+    # Clean up
+    app.dependency_overrides = {}
 
 
 @pytest_asyncio.fixture

--- a/tests_v2/conftest.py
+++ b/tests_v2/conftest.py
@@ -94,8 +94,10 @@ async def async_client(db, init_db) -> AsyncGenerator[AsyncClient, None]:
 
 
 @pytest_asyncio.fixture(scope="function")
-async def async_client_per_function(async_client) -> AsyncGenerator[AsyncClient, None]:
-    """Async Test Client that's limited to per-function scope."""
+async def async_client_per_function(db, init_db) -> AsyncGenerator[AsyncClient, None]:
+    """Async Test Client that's limited to per-function scope.
+    Use sparingly (such as when you need to clear caches) to avoid lengthier tests
+    """
     from app.main import app
 
     # mock authentication function to avoid having to reach out to RW API during tests

--- a/tests_v2/unit/app/routes/analysis/test_analysis.py
+++ b/tests_v2/unit/app/routes/analysis/test_analysis.py
@@ -79,7 +79,7 @@ async def test_analysis_with_huge_geostore(
 
 @pytest.mark.asyncio
 async def test_raster_analysis_payload_shape(
-    generic_dataset, async_client_per_function: AsyncClient, monkeypatch: MonkeyPatch
+    generic_dataset, async_client: AsyncClient, monkeypatch: MonkeyPatch
 ):
     """Note that this test depends on the output of _get_data_environment
     which will likely have cached values from other tests, so we clear it."""

--- a/tests_v2/unit/app/routes/analysis/test_analysis.py
+++ b/tests_v2/unit/app/routes/analysis/test_analysis.py
@@ -79,8 +79,11 @@ async def test_analysis_with_huge_geostore(
 
 @pytest.mark.asyncio
 async def test_raster_analysis_payload_shape(
-    generic_dataset, async_client: AsyncClient, monkeypatch: MonkeyPatch
+    generic_dataset, async_client_per_function: AsyncClient, monkeypatch: MonkeyPatch
 ):
+    """Note that we use the async_client_per_function fixture to avoid
+    the cache getting polluted from other tests"""
+
     dataset_name, _ = generic_dataset
     pixel_meaning: str = "date_conf"
     no_data_value = 0

--- a/tests_v2/unit/app/routes/analysis/test_analysis.py
+++ b/tests_v2/unit/app/routes/analysis/test_analysis.py
@@ -89,7 +89,7 @@ async def test_raster_analysis_payload_shape(
     no_data_value = 0
 
     async with custom_raster_version(
-        async_client,
+        async_client_per_function,
         dataset_name,
         monkeypatch,
         pixel_meaning=pixel_meaning,
@@ -106,7 +106,7 @@ async def test_raster_analysis_payload_shape(
         )
         monkeypatch.setattr(geostore.rw_api, "get_geostore", mock_rw_get_geostore)
 
-        _ = await async_client.get(
+        _ = await async_client_per_function.get(
             f"/analysis/zonal/17076d5ea9f214a5bdb68cc40433addb?geostore_origin=rw&group_by=umd_tree_cover_loss__year&filters=is__umd_regional_primary_forest_2001&filters=umd_tree_cover_density_2000__30&sum=area__ha&start_date=2001"
         )
         payload = mock_invoke_lambda.call_args.args[1]

--- a/tests_v2/unit/app/routes/analysis/test_analysis.py
+++ b/tests_v2/unit/app/routes/analysis/test_analysis.py
@@ -81,8 +81,8 @@ async def test_analysis_with_huge_geostore(
 async def test_raster_analysis_payload_shape(
     generic_dataset, async_client_per_function: AsyncClient, monkeypatch: MonkeyPatch
 ):
-    """Note that we use the async_client_per_function fixture to avoid
-    the cache getting polluted from other tests"""
+    """Note that this test depends on the output of _get_data_environment
+    which will likely have cached values from other tests, so we clear it."""
 
     dataset_name, _ = generic_dataset
     pixel_meaning: str = "date_conf"
@@ -105,6 +105,9 @@ async def test_raster_analysis_payload_shape(
             geostore.rw_api.get_geostore, return_value=geostore_common
         )
         monkeypatch.setattr(geostore.rw_api, "get_geostore", mock_rw_get_geostore)
+
+        # The other tests will have polluted the data env cache. Clear it.
+        queries._get_data_environment.cache_clear()
 
         _ = await async_client_per_function.get(
             f"/analysis/zonal/17076d5ea9f214a5bdb68cc40433addb?geostore_origin=rw&group_by=umd_tree_cover_loss__year&filters=is__umd_regional_primary_forest_2001&filters=umd_tree_cover_density_2000__30&sum=area__ha&start_date=2001"

--- a/tests_v2/unit/app/routes/analysis/test_analysis.py
+++ b/tests_v2/unit/app/routes/analysis/test_analysis.py
@@ -89,7 +89,7 @@ async def test_raster_analysis_payload_shape(
     no_data_value = 0
 
     async with custom_raster_version(
-        async_client_per_function,
+        async_client,
         dataset_name,
         monkeypatch,
         pixel_meaning=pixel_meaning,
@@ -109,7 +109,7 @@ async def test_raster_analysis_payload_shape(
         # The other tests will have polluted the data env cache. Clear it.
         queries._get_data_environment.cache_clear()
 
-        _ = await async_client_per_function.get(
+        _ = await async_client.get(
             f"/analysis/zonal/17076d5ea9f214a5bdb68cc40433addb?geostore_origin=rw&group_by=umd_tree_cover_loss__year&filters=is__umd_regional_primary_forest_2001&filters=umd_tree_cover_density_2000__30&sum=area__ha&start_date=2001"
         )
         payload = mock_invoke_lambda.call_args.args[1]


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [x] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- _get_data_environment (which is called every time a query is made) performs a (slow) DB query to look for assets, despite the fact that the information does not change often.

Issue Number: GTC-2779

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
- The results of _get_data_environment are cached with a time to live of 5 minutes. This should eliminate a significant portion of queries to the DB without causing much lag in acknowledging new assets.


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
