### PR TITLE
Fix expiring tile caches by giving PutBucketLifecycleConfiguration permissions to data API

### DIFF
--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -175,3 +175,11 @@ data "external" "generate_port" {
   count   = var.environment == "dev" ? 1 : 0
   program = ["python3", "${path.module}/generate_port.py", local.name_suffix, "30000", "31000"]
 }
+
+data "template_file" "tile_cache_bucket_policy" {
+  template = file("${path.root}/templates/tile_cache_bucket_policy.json.tmpl")
+
+  vars = {
+    bucket_name = data.terraform_remote_state.tile_cache.outputs.tile_cache_bucket_name
+  }
+}

--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -180,6 +180,6 @@ data "template_file" "tile_cache_bucket_policy" {
   template = file("${path.root}/templates/tile_cache_bucket_policy.json.tmpl")
 
   vars = {
-    bucket_name = data.terraform_remote_state.tile_cache.outputs.tile_cache_bucket_name
+    bucket_arn = data.terraform_remote_state.tile_cache.outputs.tile_cache_bucket_arn
   }
 }

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -33,3 +33,8 @@ resource "aws_iam_policy" "read_new_relic_secret" {
   name = substr("${local.project}-read_new-relic_secret${local.name_suffix}", 0, 64)
   policy = data.aws_iam_policy_document.read_new_relic_lic.json
 }
+
+resource "aws_iam_policy" "tile_cache_bucket_policy" {
+  name   = substr("${local.project}-tile_cache_bucket_policy${local.name_suffix}", 0, 64)
+  policy = data.template_file.tile_cache_bucket_policy.rendered
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -105,7 +105,6 @@ module "fargate_autoscaling" {
     aws_iam_policy.iam_api_gateway_policy.arn,
     aws_iam_policy.read_gcs_secret.arn,
     data.terraform_remote_state.tile_cache.outputs.ecs_update_service_policy_arn,
-    data.terraform_remote_state.tile_cache.outputs.tile_cache_bucket_full_access_policy_arn,
     aws_iam_policy.tile_cache_bucket_policy.arn,
     data.terraform_remote_state.tile_cache.outputs.cloudfront_invalidation_policy_arn
   ]

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -106,6 +106,7 @@ module "fargate_autoscaling" {
     aws_iam_policy.read_gcs_secret.arn,
     data.terraform_remote_state.tile_cache.outputs.ecs_update_service_policy_arn,
     data.terraform_remote_state.tile_cache.outputs.tile_cache_bucket_full_access_policy_arn,
+    aws_iam_policy.tile_cache_bucket_policy.arn,
     data.terraform_remote_state.tile_cache.outputs.cloudfront_invalidation_policy_arn
   ]
   task_execution_role_policies = [

--- a/terraform/templates/tile_cache_bucket_policy.json.tmpl
+++ b/terraform/templates/tile_cache_bucket_policy.json.tmpl
@@ -7,13 +7,13 @@
                 "s3:ListBucket",
                 "s3:PutLifecycleConfiguration"
             ],
-            "Resource": "${bucket_name}"
+            "Resource": "${bucket_arn}"
         },
         {
             "Effect": "Allow",
             "Action": "s3:*",
             "Resource": [
-                "${bucket_name}/*"
+                "${bucket_arn}/*"
             ]
         }
     ]

--- a/terraform/templates/tile_cache_bucket_policy.json.tmpl
+++ b/terraform/templates/tile_cache_bucket_policy.json.tmpl
@@ -5,7 +5,7 @@
             "Effect": "Allow",
             "Action": [
                 "s3:ListBucket",
-                "s3:PutLifecycleConfiguration"
+                "s3:PutBucketLifecycleConfiguration"
             ],
             "Resource": "${bucket_arn}"
         },

--- a/terraform/templates/tile_cache_bucket_policy.json.tmpl
+++ b/terraform/templates/tile_cache_bucket_policy.json.tmpl
@@ -1,0 +1,20 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:ListBucket",
+                "s3:PutLifecycleConfiguration"
+            ],
+            "Resource": "${bucket_name}"
+        },
+        {
+            "Effect": "Allow",
+            "Action": "s3:*",
+            "Resource": [
+                "${bucket_name}/*"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [x] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
- The Data API didn't have sufficient privileges to change the lifecycle configuration on the tile cache bucket (which is how one mass-expires things), thus fails to clean-up tile caches for deleted versions and assets

Issue Number: GTC-2708


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- The Data API is given sufficient privileges to change the lifecycle configuration on the tile cache bucket, and can now delete tile caches.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
