### PR TITLE
GTC-2027 (part 2) - give useful error when input geometry is not Polygon/MultiPolygon

### DIFF
--- a/app/routes/analysis/analysis.py
+++ b/app/routes/analysis/analysis.py
@@ -101,6 +101,12 @@ async def _zonal_statistics(
     start_date: Optional[str],
     end_date: Optional[str],
 ):
+    if geometry.type != "Polygon" and geometry.type != "MultiPolygon":
+        raise HTTPException(
+            status_code=400,
+            detail=f"Geometry must be a Polygon or MultiPolygon for raster analysis"
+        )
+
     # OTF will just not apply a base filter
     base = "data"
 


### PR DESCRIPTION
GTC-2027 (part 2) - give useful error when input geometry is not Polygon/MultiPolygon

This is to fix for a bunch more "tuple index out of range" 500 errors that are showing up.  Someone is submitting zonal statistic queries on geometries which are not Polygons.  This is the same as my previous fix for normal queries.

Since zonal statististics are on the way out (eventually), I didn't add a new test for this particular error case.

