### PR TITLE
Allow admins to reassign dataset owner

### DIFF
--- a/app/models/pydantic/datasets.py
+++ b/app/models/pydantic/datasets.py
@@ -1,6 +1,6 @@
 from typing import List, Optional, Union
 
-from pydantic import Field, BaseModel
+from pydantic import BaseModel, Field
 
 from .base import BaseRecord, StrictBaseModel
 from .metadata import DatasetMetadata, DatasetMetadataOut, DatasetMetadataUpdate
@@ -27,6 +27,7 @@ class DatasetCreateIn(StrictBaseModel):
 class DatasetUpdateIn(StrictBaseModel):
     is_downloadable: Optional[bool]
     metadata: Optional[DatasetMetadataUpdate]
+    owner_id: Optional[str]
 
 
 class DatasetResponse(Response):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -307,6 +307,10 @@ async def is_admin_mocked():
     return True
 
 
+async def not_admin_mocked():
+    return False
+
+
 async def is_service_account_mocked():
     return True
 

--- a/tests/routes/datasets/test_datasets.py
+++ b/tests/routes/datasets/test_datasets.py
@@ -3,7 +3,8 @@ from unittest.mock import patch
 import pytest
 
 from app.application import ContextEngine, db
-from tests import RW_USER_ID
+from app.authentication.token import is_admin
+from tests import RW_USER_ID, is_admin_mocked, not_admin_mocked
 from tests.utils import create_default_asset, dataset_metadata
 
 payload = {"metadata": dataset_metadata}
@@ -71,7 +72,7 @@ async def test_datasets(async_client):
     assert len(rows) == 1
     assert rows[0][0] == RW_USER_ID
 
-    new_payload = {"metadata": {"title": "New Title"}}
+    new_payload = {"metadata": {"title": "New Title"}, "owner_id": "new_owner_id123"}
     response = await async_client.patch(f"/dataset/{dataset}", json=new_payload)
     assert response.status_code == 200
     assert response.json()["data"]["metadata"] != payload["metadata"]
@@ -80,6 +81,25 @@ async def test_datasets(async_client):
         response.json()["data"]["metadata"]["data_language"]
         == payload["metadata"]["data_language"]
     )
+
+    async with ContextEngine("READ"):
+        rows = await db.all(
+            f"SELECT owner_id FROM datasets WHERE dataset = '{dataset}';"
+        )
+
+    assert len(rows) == 1
+    assert rows[0][0] == "new_owner_id123"
+
+    # check you can't PATCH owner_id unless admin
+    from app.main import app
+
+    app.dependency_overrides[is_admin] = not_admin_mocked
+
+    new_payload = {"owner_id": "will_fail123"}
+    response = await async_client.patch(f"/dataset/{dataset}", json=new_payload)
+    assert response.status_code == 401
+
+    app.dependency_overrides[is_admin] = is_admin_mocked
 
     response = await async_client.delete(f"/dataset/{dataset}")
     assert response.status_code == 200


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [X] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [X] Check the commit's or even all commits' message styles matches our requested structure.
- [X] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Dataset owners are assigned on dataset creation but can't be changed through the API.

Issue Number: GTC-2800


## What is the new behavior?
Admin users can now send update the owner_id PATCH requests to a dataset.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
