### PR TITLE
Pass user details when authenticating instead of a bool, check for manager on dataset creation

### DIFF
--- a/app/authentication/token.py
+++ b/app/authentication/token.py
@@ -113,9 +113,7 @@ async def get_manager(user: User = Depends(get_user)) -> User:
     """Get the details for authenticated MANAGER for data-api application or
     ADMIN user."""
 
-    if user.role != "ADMIN" or not (
-        user.role == "MANAGER" and "data-api" in user.applications
-    ):
+    if user.role != "ADMIN" or user.role != "MANAGER":
         raise HTTPException(status_code=401, detail="Unauthorized")
 
     return user

--- a/app/authentication/token.py
+++ b/app/authentication/token.py
@@ -97,7 +97,7 @@ async def get_user(token: str = Depends(oauth2_scheme)) -> User:
         logger.info("Unauthorized user")
         raise HTTPException(status_code=401, detail="Unauthorized")
     else:
-        return User(**response.json()["data"])
+        return User(**response.json())
 
 
 async def get_admin(user: User = Depends(get_user)) -> User:

--- a/app/authentication/token.py
+++ b/app/authentication/token.py
@@ -34,7 +34,7 @@ async def is_service_account(token: str = Depends(oauth2_scheme)) -> bool:
         return True
 
 
-async def is_admin(token: str = Depends(oauth2_scheme)) -> None:
+async def is_admin(token: str = Depends(oauth2_scheme)) -> bool:
     """Calls GFW API to authorize user.
 
     User must be ADMIN for gfw app
@@ -70,7 +70,11 @@ async def is_gfwpro_admin_for_query(
 
 
 async def is_app_admin(token: str, app: str, error_str: str) -> bool:
-    """Calls RW API to authorize user for specific role and app."""
+    """Calls GFW API to authorize user.
+
+    User must be an ADMIN for the specified app, else it will throw an
+    exception with the specified error string.
+    """
 
     response: Response = await who_am_i(token)
 
@@ -78,6 +82,7 @@ async def is_app_admin(token: str, app: str, error_str: str) -> bool:
         response.json()["role"] == "ADMIN"
         and app in response.json()["extraUserData"]["apps"]
     ):
+        logger.warning(f"ADMIN privileges required. Unauthorized user: {response.text}")
         raise HTTPException(status_code=401, detail=error_str)
     else:
         return True

--- a/app/models/pydantic/authentication.py
+++ b/app/models/pydantic/authentication.py
@@ -14,17 +14,18 @@ class SignUpRequestIn(StrictBaseModel):
     email: EmailStr = Query(..., description="User's email address")
 
 
-class SignUp(StrictBaseModel):
+class User(StrictBaseModel):
     id: str
     name: str
     email: EmailStr
     createdAt: datetime
     role: str
+    applications: List[str]
     extraUserData: Dict[str, Any]
 
 
 class SignUpResponse(Response):
-    data: SignUp
+    data: User
 
 
 class APIKeyRequestIn(StrictBaseModel):

--- a/app/routes/authentication/authentication.py
+++ b/app/routes/authentication/authentication.py
@@ -66,7 +66,7 @@ async def create_api_key(
     Default keys are valid for one year
     """
 
-    user_id, user_role = user["id"], user["role"]
+    user_id, user_role = user.id, user.role
 
     if api_key_data.never_expires and user_role != "ADMIN":
         raise HTTPException(
@@ -124,7 +124,7 @@ async def get_api_key(
 
     User must own API Key or must be Admin to see details.
     """
-    user_id, role = user["id"], user["role"]
+    user_id, role = user.id, user.role
     try:
         row: ORMApiKey = await api_keys.get_api_key(api_key)
     except RecordNotFoundError:
@@ -148,7 +148,7 @@ async def get_api_keys(
 
     Default keys are valid for one year
     """
-    user_id = user["id"]
+    user_id = user.id
     rows: List[ORMApiKey] = await api_keys.get_api_keys_from_user(user_id)
     data = [ApiKey.from_orm(row) for row in rows]
 
@@ -191,7 +191,7 @@ async def delete_api_key(
 
     API Key must belong to user.
     """
-    user_id = user["id"]
+    user_id = user.id
     try:
         row: ORMApiKey = await api_keys.get_api_key(api_key)
     except RecordNotFoundError:

--- a/app/routes/authentication/authentication.py
+++ b/app/routes/authentication/authentication.py
@@ -66,12 +66,10 @@ async def create_api_key(
     Default keys are valid for one year
     """
 
-    user_id, user_role = user.id, user.role
-
-    if api_key_data.never_expires and user_role != "ADMIN":
+    if api_key_data.never_expires and user.role != "ADMIN":
         raise HTTPException(
             status_code=400,
-            detail=f"Users with role {user_role} cannot set `never_expires` to True.",
+            detail=f"Users with role {user.role} cannot set `never_expires` to True.",
         )
 
     input_data = api_key_data.dict(by_alias=True)
@@ -86,7 +84,7 @@ async def create_api_key(
 
     # Give a good error code/message if user is specifying an alias that exists for
     # another one of his API keys.
-    prev_keys: List[ORMApiKey] = await api_keys.get_api_keys_from_user(user_id=user_id)
+    prev_keys: List[ORMApiKey] = await api_keys.get_api_keys_from_user(user_id=user.id)
     for key in prev_keys:
         if key.alias == api_key_data.alias:
             raise HTTPException(
@@ -94,7 +92,7 @@ async def create_api_key(
                 detail="Key with specified alias already exists; use a different alias",
             )
 
-    row: ORMApiKey = await api_keys.create_api_key(user_id=user_id, **input_data)
+    row: ORMApiKey = await api_keys.create_api_key(user_id=user.id, **input_data)
 
     is_internal = api_key_is_internal(
         api_key_data.domains, user_id=None, origin=origin, referrer=referrer

--- a/app/utils/rw_api.py
+++ b/app/utils/rw_api.py
@@ -12,7 +12,7 @@ from ..errors import (
     RecordNotFoundError,
     UnauthorizedError,
 )
-from ..models.pydantic.authentication import SignUp
+from ..models.pydantic.authentication import User
 from ..models.pydantic.geostore import Geometry, GeostoreCommon
 from ..settings.globals import RW_API_URL
 
@@ -116,7 +116,7 @@ async def login(user_name: str, password: str) -> str:
     return response.json()["data"]["token"]
 
 
-async def signup(name: str, email: str) -> SignUp:
+async def signup(name: str, email: str) -> User:
     """Obtain a token form RW API using given user name and password."""
 
     headers = {"Content-Type": "application/json"}
@@ -153,4 +153,4 @@ async def signup(name: str, email: str) -> SignUp:
             detail="An error occurred while trying to create a new user account. Please try again.",
         )
 
-    return SignUp(**response.json()["data"])
+    return User(**response.json()["data"])

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -12,6 +12,7 @@ from moto import mock_batch, mock_ec2, mock_ecs, mock_iam, mock_lambda, mock_log
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
 
+from app.models.pydantic.authentication import User
 from app.settings.globals import (
     AWS_REGION,
     DATA_LAKE_BUCKET,
@@ -50,8 +51,6 @@ SHP_PATH = os.path.join(os.path.dirname(__file__), "fixtures", SHP_NAME)
 
 BUCKET = "test-bucket"
 PORT = 9000
-
-RW_USER_ID = "5874bfcca049b7a56ad42771"  # pragma: allowlist secret
 
 SessionLocal: Optional[Session] = None
 
@@ -315,8 +314,16 @@ async def get_api_key_mocked() -> Tuple[Optional[str], Optional[str]]:
     return str(uuid.uuid4()), "localhost"
 
 
-async def get_rw_user_id() -> str:
-    return RW_USER_ID
+async def get_manager_mocked() -> User:
+    return User(
+        id="mr_manager123",
+        name="Mr. Manager",
+        email="mr_manager@management.com",
+        createdAt="2021-06-13T03:18:23.000Z",
+        role="MANAGER",
+        applications=["data-api"],
+        extraUserData={},
+    )
 
 
 def setup_clients(ec2_client, iam_client):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -321,7 +321,7 @@ async def get_manager_mocked() -> User:
         email="mr_manager@management.com",
         createdAt="2021-06-13T03:18:23.000Z",
         role="MANAGER",
-        applications=["data-api"],
+        applications=[],
         extraUserData={},
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,7 @@ from fastapi.testclient import TestClient
 from httpx import AsyncClient
 
 from app.authentication.api_keys import get_api_key
-from app.authentication.token import is_admin, is_service_account, rw_user_id
+from app.authentication.token import get_manager, is_admin, is_service_account
 from app.settings.globals import (
     AURORA_JOB_QUEUE,
     AURORA_JOB_QUEUE_FAST,
@@ -52,7 +52,7 @@ from . import (
     AWSMock,
     MemoryServer,
     get_api_key_mocked,
-    get_rw_user_id,
+    get_manager_mocked,
     is_admin_mocked,
     is_service_account_mocked,
     setup_clients,
@@ -252,7 +252,7 @@ async def async_client():
     app.dependency_overrides[is_admin] = is_admin_mocked
     app.dependency_overrides[is_service_account] = is_service_account_mocked
     app.dependency_overrides[get_api_key] = get_api_key_mocked
-    app.dependency_overrides[rw_user_id] = get_rw_user_id
+    app.dependency_overrides[get_manager] = get_manager_mocked
 
     async with AsyncClient(app=app, base_url="http://test", trust_env=False) as client:
         yield client

--- a/tests/routes/datasets/test_datasets.py
+++ b/tests/routes/datasets/test_datasets.py
@@ -3,7 +3,6 @@ from unittest.mock import patch
 import pytest
 
 from app.application import ContextEngine, db
-from tests import RW_USER_ID
 from tests.utils import create_default_asset, dataset_metadata
 
 payload = {"metadata": dataset_metadata}
@@ -69,7 +68,7 @@ async def test_datasets(async_client):
         )
 
     assert len(rows) == 1
-    assert rows[0][0] == RW_USER_ID
+    assert rows[0][0] == "mr_manager123"
 
     new_payload = {"metadata": {"title": "New Title"}}
     response = await async_client.patch(f"/dataset/{dataset}", json=new_payload)

--- a/tests_v2/conftest.py
+++ b/tests_v2/conftest.py
@@ -11,7 +11,7 @@ from alembic.config import main
 from fastapi.testclient import TestClient
 from httpx import AsyncClient
 
-from app.authentication.token import get_user, is_admin, is_service_account, rw_user_id
+from app.authentication.token import get_manager, get_user, is_admin, is_service_account
 from app.crud import api_keys
 from app.models.enum.change_log import ChangeLogStatus
 from app.models.pydantic.change_log import ChangeLog
@@ -31,7 +31,7 @@ from tests_v2.utils import (
     dict_function_closure,
     get_admin_mocked,
     get_extent_mocked,
-    get_rw_user_id_mocked,
+    get_manager_mocked,
     get_user_mocked,
     int_function_closure,
     void_coroutine,
@@ -81,7 +81,7 @@ async def async_client(db, init_db) -> AsyncGenerator[AsyncClient, None]:
         True, with_args=False
     )
     app.dependency_overrides[get_user] = get_admin_mocked
-    app.dependency_overrides[rw_user_id] = get_rw_user_id_mocked
+    app.dependency_overrides[get_manager] = get_manager_mocked
 
     async with AsyncClient(
         app=app,

--- a/tests_v2/utils.py
+++ b/tests_v2/utils.py
@@ -63,7 +63,7 @@ async def get_manager_mocked() -> str:
         email="mr_manager@management.com",
         createdAt="2021-06-13T03:18:23.000Z",
         role="MANAGER",
-        applications=["data-api"],
+        applications=[],
         extraUserData={},
     )
 

--- a/tests_v2/utils.py
+++ b/tests_v2/utils.py
@@ -33,11 +33,27 @@ class BatchJobMock:
 
 
 async def get_user_mocked() -> Tuple[str, str]:
-    return "userid_123", "USER"
+    return User(
+        id="userid_123",
+        name="Ms. User",
+        email="ms_user@user.com",
+        createdAt="2021-06-13T03:18:23.000Z",
+        role="USER",
+        applications=[],
+        extraUserData={},
+    )
 
 
 async def get_admin_mocked() -> Tuple[str, str]:
-    return "adminid_123", "ADMIN"
+    return User(
+        id="adminid_123",
+        name="Sir Admin",
+        email="sir_admin@admin.com",
+        createdAt="2021-06-13T03:18:23.000Z",
+        role="ADMIN",
+        applications=[],
+        extraUserData={},
+    )
 
 
 async def get_manager_mocked() -> str:

--- a/tests_v2/utils.py
+++ b/tests_v2/utils.py
@@ -8,6 +8,7 @@ import httpx
 from _pytest.monkeypatch import MonkeyPatch
 
 from app.application import ContextEngine
+from app.models.pydantic.authentication import User
 from app.models.pydantic.extent import Extent
 from app.routes.datasets import versions
 from app.tasks import batch, delete_assets
@@ -39,8 +40,16 @@ async def get_admin_mocked() -> Tuple[str, str]:
     return "adminid_123", "ADMIN"
 
 
-async def get_rw_user_id_mocked() -> str:
-    return "userid_123"
+async def get_manager_mocked() -> str:
+    return User(
+        id="mr_manager123",
+        name="Mr. Manager",
+        email="mr_manager@management.com",
+        createdAt="2021-06-13T03:18:23.000Z",
+        role="MANAGER",
+        applications=["data-api"],
+        extraUserData={},
+    )
 
 
 async def get_api_key_mocked() -> Tuple[Optional[str], Optional[str]]:


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [ ] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [ ] Check the commit's or even all commits' message styles matches our requested structure.
- [ ] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
Currently we just return a bool when checking authentication for most routes, except we really just throw an exception if the check fails.

Issue Number: GTC-2820


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Return a User object which contains all the details of a user when authenticating/authorizing, or throw an exception if the user isn't authorized. This is more in line with what FastAPI has in their [auth example](https://fastapi.tiangolo.com/tutorial/security/get-current-user/). This makes more sense than a boolean that never returns false, and provides an object with details we can use for other behavior (e.g. save ID as owner, return email of owner in error message, check orgs/apps, etc.)
- Add an initial use for setting the manager as owner when creating a dataset.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
