### PR TITLE
GTC-2822 Check for dataset ownership on asset requests

### DIFF
--- a/app/authentication/token.py
+++ b/app/authentication/token.py
@@ -95,7 +95,7 @@ async def get_user(token: str = Depends(oauth2_scheme)) -> User:
 
     if response.status_code == 401:
         logger.info("Unauthorized user")
-        raise HTTPException(status_code=401, detail="Unauthorized")
+        raise HTTPException(status_code=401, detail="Unauthorized access - this operation requires user authentication via a token")
     else:
         return User(**response.json())
 
@@ -104,7 +104,7 @@ async def get_admin(user: User = Depends(get_user)) -> User:
     """Get the details for authenticated ADMIN user."""
 
     if user.role != "ADMIN":
-        raise HTTPException(status_code=401, detail="Unauthorized")
+        raise HTTPException(status_code=401, detail="Unauthorized access - this operation requires authentication as a user that is an admin")
 
     return user
 
@@ -114,6 +114,6 @@ async def get_manager(user: User = Depends(get_user)) -> User:
     ADMIN user."""
 
     if user.role != "ADMIN" or user.role != "MANAGER":
-        raise HTTPException(status_code=401, detail="Unauthorized")
+        raise HTTPException(status_code=401, detail="Unauthorized write access to a dataset/version/asset by a user who is not an admin or data manager")
 
     return user

--- a/app/routes/assets/asset.py
+++ b/app/routes/assets/asset.py
@@ -71,6 +71,10 @@ from ...utils.path import infer_srid_from_grid
 from ..assets import asset_response
 from ..tasks import paginated_tasks_response, tasks_response
 
+from ...authentication.token import get_manager
+from ...models.pydantic.authentication import User
+from ..datasets.dataset import get_owner
+
 router = APIRouter()
 
 
@@ -103,12 +107,20 @@ async def update_asset(
     *,
     asset_id: UUID = Path(...),
     request: AssetUpdateIn,
-    is_authorized: bool = Depends(is_admin),
+    user: User = Depends(get_manager),
 ) -> AssetResponse:
     """Update Asset metadata.
 
     Only the dataset's owner or a user with `ADMIN` user role can do this operation.
     """
+
+    try:
+        asset_row: ORMAsset = await assets.get_asset(asset_id)
+    except RecordNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+
+    # This is the actual check that the user is either the dataset owner or an admin
+    _ = await get_owner(asset_row.dataset, user)
 
     input_data = request.dict(exclude_none=True, by_alias=True)
 
@@ -133,7 +145,7 @@ async def update_asset(
 async def delete_asset(
     *,
     asset_id: UUID = Path(...),
-    is_authorized: bool = Depends(is_admin),
+    user: User = Depends(get_manager),
     background_tasks: BackgroundTasks,
 ) -> AssetResponse:
     """Delete selected asset.
@@ -148,6 +160,9 @@ async def delete_asset(
         row: ORMAsset = await assets.get_asset(asset_id)
     except RecordNotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e))
+
+    # This is the actual check that the user is either the dataset owner or an admin
+    _ = await get_owner(row.dataset, user)
 
     if row.is_default:
         raise HTTPException(
@@ -346,12 +361,22 @@ async def get_field_metadata(*, asset_id: UUID = Path(...), field_name: str):
     response_model=FieldMetadataResponse,
 )
 async def update_field_metadata(
-    *, asset_id: UUID = Path(...), field_name: str, request: FieldMetadataUpdate
+    *, asset_id: UUID = Path(...), field_name: str, request: FieldMetadataUpdate,
+    user: User = Depends(get_manager),
 ):
     """Update the field metadata for an asset.
 
     Only the dataset's owner or a user with `ADMIN` user role can do this operation.
     """
+
+    try:
+        asset_row: ORMAsset = await assets.get_asset(asset_id)
+    except RecordNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+
+    # This is the actual check that the user is either the dataset owner or an admin
+    _ = await get_owner(asset_row.dataset, user)
+
     input_data = request.dict(exclude_none=True, by_alias=True)
     metadata = await metadata_crud.get_asset_metadata(asset_id)
     field_metadata: ORMFieldMetadata = await metadata_crud.update_field_metadata(
@@ -410,7 +435,8 @@ async def create_metadata(*, asset_id: UUID = Path(...), request: AssetMetadata)
     tags=["Assets"],
     response_model=AssetMetadataResponse,
 )
-async def update_metadata(*, asset_id: UUID = Path(...), request: AssetMetadataUpdate):
+async def update_metadata(*, asset_id: UUID = Path(...), request: AssetMetadataUpdate,
+                          user: User = Depends(get_manager)):
     """Update metadata record for an asset.
 
     Only the dataset's owner or a user with `ADMIN` user role can do this operation.
@@ -426,6 +452,9 @@ async def update_metadata(*, asset_id: UUID = Path(...), request: AssetMetadataU
     except RecordNotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e))
 
+    # This is the actual check that the user is either the dataset owner or an admin
+    _ = await get_owner(asset.dataset, user)
+
     validated_metadata = asset_metadata_factory(asset)
 
     return Response(data=validated_metadata)
@@ -437,7 +466,8 @@ async def update_metadata(*, asset_id: UUID = Path(...), request: AssetMetadataU
     tags=["Assets"],
     response_model=AssetMetadataResponse,
 )
-async def delete_metadata(asset_id: UUID = Path(...)):
+async def delete_metadata(asset_id: UUID = Path(...),
+                          user: User = Depends(get_manager)):
     """Delete an asset's metadata record.
 
     Only the dataset's owner or a user with `ADMIN` user role can do this operation.
@@ -447,6 +477,9 @@ async def delete_metadata(asset_id: UUID = Path(...)):
         asset.metadata = await metadata_crud.delete_asset_metadata(asset_id)
     except RecordNotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e))
+
+    # This is the actual check that the user is either the dataset owner or an admin
+    _ = await get_owner(asset.dataset, user)
 
     validated_metadata = asset_metadata_factory(asset)
 

--- a/app/routes/datasets/asset.py
+++ b/app/routes/datasets/asset.py
@@ -20,6 +20,7 @@ from ...authentication.token import is_admin
 from ...crud import assets
 from ...errors import RecordAlreadyExistsError
 from ...models.orm.assets import Asset as ORMAsset
+from ...models.pydantic.authentication import User
 from ...models.pydantic.assets import (
     AssetCreateIn,
     AssetResponse,
@@ -32,6 +33,7 @@ from ...tasks.assets import put_asset
 from ...utils.paginate import paginate_collection
 from ...utils.path import get_asset_uri
 from ..assets import asset_response, assets_response, paginated_assets_response
+from .dataset import get_owner
 from . import (
     validate_creation_options,
     verify_asset_dependencies,
@@ -118,7 +120,7 @@ async def add_new_asset(
     dv: Tuple[str, str] = Depends(dataset_version_dependency),
     request: AssetCreateIn,
     background_tasks: BackgroundTasks,
-    is_authorized: bool = Depends(is_admin),
+    is_authorized: User = Depends(get_owner),
     response: ORJSONResponse,
 ) -> AssetResponse:
     """Add a new asset to a dataset version. Managed assets will be generated

--- a/app/routes/datasets/dataset.py
+++ b/app/routes/datasets/dataset.py
@@ -28,13 +28,15 @@ router = APIRouter()
 async def get_owner(
     dataset: str = Depends(dataset_dependency), user: User = Depends(get_manager)
 ) -> User:
-    """Retrieves the user object that owns the dataset if that user is the one
-    making the request, otherwise raises a 401."""
+    """Returns the User making the request as long as that user is an admin or
+    the owner of the dataset, otherwise raises a 401."""
 
+    if user.role == "ADMIN":
+        return user
     dataset_row: ORMDataset = await datasets.get_dataset(dataset)
     owner: str = dataset_row.owner_id
     if owner != user.id:
-        raise HTTPException(status_code=401, detail="Unauthorized")
+        raise HTTPException(status_code=401, detail=f"Unauthorized write access to dataset {dataset} (or its versions/assets) by a user who is not an admin or owner of the dataset")
     return user
 
 

--- a/tests_v2/unit/app/routes/datasets/test_dataset.py
+++ b/tests_v2/unit/app/routes/datasets/test_dataset.py
@@ -45,9 +45,10 @@ async def test_get_owner_fail(db, init_db, monkeypatch) -> None:
         _ = await get_owner(dataset_name, some_user)
     except HTTPException as e:
         assert e.status_code == 401
-        assert e.detail == "Unauthorized"
+        assert e.detail == "Unauthorized write access to dataset my_first_dataset (or its versions/assets) by a user who is not an admin or owner of the dataset"
 
 
+@pytest.mark.asyncio
 async def test_get_owner_manager_success(db, init_db, monkeypatch) -> None:
     dataset_name: str = "my_first_dataset"
 
@@ -74,6 +75,7 @@ async def test_get_owner_manager_success(db, init_db, monkeypatch) -> None:
     _ = await get_owner(dataset_name, some_manager)
 
 
+@pytest.mark.asyncio
 async def test_get_owner_different_manager_fail(db, init_db, monkeypatch) -> None:
     dataset_name: str = "my_first_dataset"
 
@@ -102,16 +104,17 @@ async def test_get_owner_different_manager_fail(db, init_db, monkeypatch) -> Non
         _ = await get_owner(dataset_name, some_manager)
     except HTTPException as e:
         assert e.status_code == 401
-        assert e.detail == "Unauthorized"
+        assert e.detail == "Unauthorized write access to dataset my_first_dataset (or its versions/assets) by a user who is not an admin or owner of the dataset"
 
 
+@pytest.mark.asyncio
 async def test_get_owner_admin_success(db, init_db, monkeypatch) -> None:
     dataset_name: str = "my_first_dataset"
 
     from app.main import app
 
-    # Create a dataset
-    app.dependency_overrides[get_manager] = get_admin_mocked
+    # Create a dataset with a manager, then make sure get_owner succeeds with an admin.
+    app.dependency_overrides[get_manager] = get_manager_mocked
 
     async with AsyncClient(
         app=app,


### PR DESCRIPTION
GTC-2822 Check for dataset ownership on asset requests

Make use of get_owner in the asset operations.

The checks for the pure asset operations were slightly trickier than dataset/version operations, because the dataset name is available in the URL path. You need to do a DB operation to get the dataset name. So, I put the actual get_owner() call in the main function rather than in a Depends() argument. I didn't try to add a new Depends() function that magically does the DB operation, since some of the functions already do the DB operation for other reasons.

Updated the test for update_metadata and update_field_metadata to test success and failure cases for different users.

Added a missing check for the ADMIN role in get_owner() and updated its comment.

Updated the detail of the various permission exceptions to be more informative (GTC-2795). Let me know what you think. We could put a bit more information in these messages if we did these errors in the main functions, rather than in the Depends functions, but that is probably not worth it.

In test_dataset.py, several tests were being skipped unintentionally because they were missing the '@pytyest.mark.asyncio' annotation, so I added that in where needed.
