### PR TITLE
GTC-2788 Specify asyncpg.pgproto.pgproto.UUID fully.

### DIFF
--- a/app/responses.py
+++ b/app/responses.py
@@ -1,6 +1,7 @@
 import decimal
 import io
 from typing import Any
+import asyncpg
 
 import orjson
 from fastapi.responses import Response, StreamingResponse
@@ -74,7 +75,7 @@ def jsonencoder_lite(obj):
     encoding large lists. This encoder only encodes the bare necessities
     needed to work with serializers like ORJSON.
     """
-    if isinstance(obj, decimal.Decimal) or isinstance(obj, UUID):
+    if isinstance(obj, decimal.Decimal) or isinstance(obj, asyncpg.pgproto.pgproto.UUID):
         return str(obj)
     raise TypeError(
         f"Unknown type for value {obj} with class type {type(obj).__name__}"


### PR DESCRIPTION
Do proper serialization for UUIDs.  Specify asyncpg.pgproto.pgproto.UUID fully.
In my previous change, UUID probably referred to uuid.UUID.

This is in case there is a unusual query that does SELECT(*) on a
dataset that has a UUID field. Currently, we get a 500 with an error
"TypeError: Type is not JSON serializable: asyncpg.pgproto.pgproto.UUID"


