### PR TITLE
allow users to specify non-globalforestwatch domains in api key

### DIFF
--- a/app/authentication/api_keys.py
+++ b/app/authentication/api_keys.py
@@ -93,32 +93,14 @@ def api_key_is_valid(
     return is_valid
 
 
-def api_key_is_internal(
-    domains: List[str],
-    user_id: Optional[str] = None,
-    origin: Optional[str] = None,
-    referrer: Optional[str] = None,
-) -> bool:
-
-    is_internal: bool = False
-    if origin and domains:
-        is_internal = any(
-            [
-                re.search(_to_regex(internal_domain.strip()), domain)
-                for domain in domains
-                for internal_domain in INTERNAL_DOMAINS.split(",")
-            ]
-        )
-    elif referrer and domains:
-        is_internal = any(
-            [
-                re.search(_to_regex(domain), internal_domain)
-                for domain in domains
-                for internal_domain in INTERNAL_DOMAINS.split(",")
-            ]
-        )
-
-    return is_internal
+def api_key_is_internal(domains: List[str]) -> bool:
+    return any(
+        [
+            re.search(_to_regex(internal_domain.strip()), domain)
+            for domain in domains
+            for internal_domain in INTERNAL_DOMAINS.split(",")
+        ]
+    )
 
 
 def _api_key_origin_auto_error(
@@ -139,7 +121,7 @@ def _api_key_origin_auto_error(
 
 def _to_regex(domain):
     result = domain.replace(".", r"\.").replace("*", ".*")
-    return fr"^{result}$"
+    return rf"^{result}$"
 
 
 def _extract_domain(url: str) -> str:

--- a/app/routes/authentication/authentication.py
+++ b/app/routes/authentication/authentication.py
@@ -74,16 +74,8 @@ async def create_api_key(
 
     input_data = api_key_data.dict(by_alias=True)
 
-    origin = request.headers.get("origin")
-    referrer = request.headers.get("referer")
-    if not api_key_is_valid(input_data["domains"], origin=origin, referrer=referrer):
-        raise HTTPException(
-            status_code=400,
-            detail="Domain name did not match the request origin or referrer.",
-        )
-
     # Give a good error code/message if user is specifying an alias that exists for
-    # another one of his API keys.
+    # another one of their API keys.
     prev_keys: List[ORMApiKey] = await api_keys.get_api_keys_from_user(user_id=user.id)
     for key in prev_keys:
         if key.alias == api_key_data.alias:
@@ -94,9 +86,7 @@ async def create_api_key(
 
     row: ORMApiKey = await api_keys.create_api_key(user_id=user.id, **input_data)
 
-    is_internal = api_key_is_internal(
-        api_key_data.domains, user_id=None, origin=origin, referrer=referrer
-    )
+    is_internal = api_key_is_internal(api_key_data.domains)
     usage_plan_id = (
         API_GATEWAY_INTERNAL_USAGE_PLAN
         if is_internal is True

--- a/app/settings/globals.py
+++ b/app/settings/globals.py
@@ -178,6 +178,7 @@ default_domains = ",".join(
         "api.resourcewatch.org",
         "my.gfw-mapbuilder.org",
         "resourcewatch.org",
+        "*.wri.org",
     ]
 )
 


### PR DESCRIPTION


<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [x] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Creating api key from non-globalforestwatch origins fails now if the user passes domains list that doesn't include globalforestwatch. 


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Users can create api key for non-GFW domains

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
