### PR TITLE
GTC-2788 Do proper serialization for UUIDs - hotfix to master

### DIFF
--- a/app/responses.py
+++ b/app/responses.py
@@ -1,6 +1,7 @@
 import decimal
 import io
 from typing import Any
+import asyncpg
 
 import orjson
 from fastapi.responses import Response, StreamingResponse
@@ -74,7 +75,7 @@ def jsonencoder_lite(obj):
     encoding large lists. This encoder only encodes the bare necessities
     needed to work with serializers like ORJSON.
     """
-    if isinstance(obj, decimal.Decimal):
+    if isinstance(obj, decimal.Decimal) or isinstance(obj, asyncpg.pgproto.pgproto.UUID):
         return str(obj)
     raise TypeError(
         f"Unknown type for value {obj} with class type {type(obj).__name__}"


### PR DESCRIPTION
This is in case there is a unusual query that does SELECT(*) on a dataset that has a UUID field. Currently, we get a 500 with an error "TypeError: Type is not JSON serializable: asyncpg.pgproto.pgproto.UUID".

We need to force UUID to str so it can be serialized, just as we are already doing with Decimal.
