### PR TITLE
Change github destroy action back to way it was in February.

### DIFF
--- a/.github/workflows/terraform_destroy_on_delete.yaml
+++ b/.github/workflows/terraform_destroy_on_delete.yaml
@@ -4,7 +4,7 @@ on: [delete]
 
 jobs:
   build:
-    if: contains(github.event.ref_type, 'branch') &&  (! github.event.ref == 'master') && (! github.event.ref == 'develop')
+    if: contains(github.event.ref_type, 'branch') &&  (! contains(github.event.ref, 'master')) && (! contains(github.event.ref, 'develop'))
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/terraform_destroy_on_delete.yaml
+++ b/.github/workflows/terraform_destroy_on_delete.yaml
@@ -4,7 +4,7 @@ on: [delete]
 
 jobs:
   build:
-    if: contains(github.event.ref_type, 'branch') &&  (! contains(github.event.ref, 'master')) && (! contains(github.event.ref, 'develop'))
+    if: github.event.ref_type == 'branch' && (github.event.ref != 'refs/heads/master') && (github.event.ref != 'refs/heads/develop')
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
Change github destroy action back to way it was in February.

I think this should get the destroy operation running again (not skipped), when a feature branch is deleted.
