### PR TITLE
Reduce TTL on latest version cache

### DIFF
--- a/app/crud/versions.py
+++ b/app/crud/versions.py
@@ -52,9 +52,12 @@ async def get_version(dataset: str, version: str) -> ORMVersion:
     return row
 
 
-@alru_cache(maxsize=64, ttl=3600.0)
+@alru_cache(maxsize=64, ttl=15.0)
 async def get_latest_version(dataset) -> str:
     """Fetch latest version number."""
+    # NOTE: Even though we invalidate cache entries in the known mutator
+    # functions, set cache TTL to a low value to reduce incoherency between
+    # ECS instances.
 
     latest: Optional[str] = (
         await ORMVersion.select("version")


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [ ] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
One API instance caches the version (possibly when setting a new one), but the other doesn't. The long (1 hour) TTL means that they can stay out of sync for such a long time that things like the datapump (randomly) get inconsistent results.


Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- The TTL is reduced to 15s, which is less than the datapump's step function iteration time (and should be short enough for general purposes).

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->