### PR TITLE
Fix so github destroy action runs again (isn't skipped)

### DIFF
--- a/.github/workflows/terraform_destroy_on_delete.yaml
+++ b/.github/workflows/terraform_destroy_on_delete.yaml
@@ -4,7 +4,7 @@ on: [delete]
 
 jobs:
   build:
-    if: contains(github.event.ref_type, 'branch') &&  (! github.event.ref == 'master') && (! github.event.ref == 'develop')
+    if: github.event.ref_type == 'branch' && (github.event.ref != 'refs/heads/master') && (github.event.ref != 'refs/heads/develop')
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
The syntax for checking that the branch was not master and not develop was incorrect.

Merging this fix to master, so it can start being used right away.
