### PR TITLE
GTC-2868 Force use of only XY (2 dimensions) from the dataset

### DIFF
--- a/batch/scripts/create_vector_schema.sh
+++ b/batch/scripts/create_vector_schema.sh
@@ -37,7 +37,7 @@ args=(-f "PostgreSQL" PG:"password=$PGPASSWORD host=$PGHOST port=$PGPORT dbname=
      "$LOCAL_FILE" "$SRC_LAYER" \
      -nlt PROMOTE_TO_MULTI -nln "$DATASET.$VERSION" \
      -lco GEOMETRY_NAME="$GEOMETRY_NAME" -lco SPATIAL_INDEX=NONE -lco FID="$FID_NAME" \
-     -t_srs EPSG:4326 -limit 0)
+     -t_srs EPSG:4326 -limit 0 -dim xy)
 
 # If source is CSV, there's no SRS information so add it manually
 if [[ "$SRC" == *".csv" ]]; then

--- a/batch/scripts/load_vector_data.sh
+++ b/batch/scripts/load_vector_data.sh
@@ -94,4 +94,5 @@ ogr2ogr -f "PostgreSQL" PG:"password=$PGPASSWORD host=$PGHOST port=$PGPORT dbnam
   -nln $TEMP_TABLE \
   -t_srs EPSG:4326 \
   --config PG_USE_COPY YES \
+  -dim xy \
   -makevalid -update


### PR DESCRIPTION
GTC-2868 Force use of only XY (2 dimensions) from the dataset

Added "-dim xy" (same as "-dim 2") to the ogr2ogr command line.
