### PR TITLE
GTC-2864 Make test output for Data API be less verbose by default

### DIFF
--- a/.github/workflows/terraform_build.yaml
+++ b/.github/workflows/terraform_build.yaml
@@ -12,8 +12,8 @@ jobs:
 
     - name: Test with pytest
       run: |
-        ./scripts/test
-        ./scripts/test_v2 --no_build
+        ./scripts/test --do-cov
+        ./scripts/test_v2 --no_build --do-cov
 
     - name: Run codacy-coverage-reporter
       uses: codacy/codacy-coverage-reporter-action@master

--- a/.github/workflows/terraform_build.yaml
+++ b/.github/workflows/terraform_build.yaml
@@ -12,8 +12,8 @@ jobs:
 
     - name: Test with pytest
       run: |
-        ./scripts/test --do-cov
-        ./scripts/test_v2 --no_build --do-cov
+        ./scripts/test --do-cov --show-warnings
+        ./scripts/test_v2 --no_build --do-cov --show-warnings
 
     - name: Run codacy-coverage-reporter
       uses: codacy/codacy-coverage-reporter-action@master

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -64,7 +64,7 @@ services:
       - API_GATEWAY_STAGE_NAME=test
       - AWS_GCS_KEY_SECRET_ARN=testing
       - AWS_SECRETSMANAGER_URL=http://motoserver:50000
-    entrypoint: wait_for_postgres.sh pytest --timeout 480 -vv --cov-report term  --cov=app
+    entrypoint: wait_for_postgres.sh pytest --timeout 480 -vv --cov-report term
     depends_on:
       - test_database_12
       - motoserver

--- a/scripts/test
+++ b/scripts/test
@@ -55,7 +55,7 @@ set -- "${POSITIONAL[@]}" # restore positional parameters
 
 # If no tests specified, do whole tests directory
 args=$*
-if [ $# -eq 0 ];
+if [ $# -eq 0 ]; then
    args=tests
 fi
 

--- a/scripts/test
+++ b/scripts/test
@@ -53,6 +53,11 @@ do
 done
 set -- "${POSITIONAL[@]}" # restore positional parameters
 
+# If no tests specified, do whole tests directory
+args=$*
+if [ $# -eq 0 ];
+   args=tests
+fi
 
 if [ "${BUILD}" = true ]; then
   docker build -t batch_gdal-python_test . -f batch/gdal-python.dockerfile
@@ -65,7 +70,7 @@ fi
 set +e
 
 # Everything from "--cov-report on" become the arguments to the pytest run inside the docker.
-docker-compose -f docker-compose.test.yml --project-name gfw-data-api_test run --rm --name app_test app_test --cov-report xml:/app/tests/cobertura.xml $HANGING $SLOW  $DO_COV $DISABLE_WARNINGS $SHOW_STDOUT tests/"$*"
+docker-compose -f docker-compose.test.yml --project-name gfw-data-api_test run --rm --name app_test app_test --cov-report xml:/app/tests/cobertura.xml $HANGING $SLOW  $DO_COV $DISABLE_WARNINGS $SHOW_STDOUT $args
 exit_code=$?
 docker-compose -f docker-compose.test.yml --project-name gfw-data-api_test down --remove-orphans
 exit $exit_code

--- a/scripts/test
+++ b/scripts/test
@@ -6,6 +6,9 @@ set -e
 # Default values
 POSITIONAL=()
 BUILD=true
+DO_COV=
+DISABLE_WARNINGS="--disable-warnings"
+SHOW_STDOUT=
 # extracting cmd line arguments
 while [[ $# -gt 0 ]]
 do
@@ -22,6 +25,18 @@ do
       ;;
       --with-slow-tests)
       SLOW=--with-slow-tests
+      shift # past argument
+      ;;
+      --do-cov)
+      DO_COV=--cov=app
+      shift # past argument
+      ;;
+      --show-warnings)
+      DISABLE_WARNINGS=
+      shift # past argument
+      ;;
+      --show-stdout)
+      SHOW_STDOUT=--capture=no
       shift # past argument
       ;;
       --moto-port=*)
@@ -48,7 +63,9 @@ if [ "${BUILD}" = true ]; then
 fi
 
 set +e
-docker-compose -f docker-compose.test.yml --project-name gfw-data-api_test run --rm --name app_test app_test $HANGING $SLOW --cov-report xml:/app/tests/cobertura.xml tests/"$*"
+
+# Everything from "--cov-report on" become the arguments to the pytest run inside the docker.
+docker-compose -f docker-compose.test.yml --project-name gfw-data-api_test run --rm --name app_test app_test --cov-report xml:/app/tests/cobertura.xml $HANGING $SLOW  $DO_COV $DISABLE_WARNINGS $SHOW_STDOUT tests/"$*"
 exit_code=$?
 docker-compose -f docker-compose.test.yml --project-name gfw-data-api_test down --remove-orphans
 exit $exit_code

--- a/scripts/test_v2
+++ b/scripts/test_v2
@@ -45,6 +45,12 @@ do
 done
 set -- "${POSITIONAL[@]}" # restore positional parameters
 
+# If no tests specified, do whole tests_v2 directory
+args=$*
+if [ $# -eq 0 ]; then
+   args=tests_v2
+fi
+
 if [ "${BUILD}" = true ]; then
   docker build -t batch_gdal-python_test . -f batch/gdal-python.dockerfile
   docker build -t batch_postgresql-client_test . -f batch/postgresql-client.dockerfile
@@ -56,7 +62,7 @@ fi
 set +e
 
 # Everything from "--cov-report on" become the arguments to the pytest run inside the docker.
-docker-compose -f docker-compose.test.yml --project-name gfw-data-api_test run --rm --name app_test app_test --cov-report xml:/app/tests_v2/cobertura.xml $DO_COV $DISABLE_WARNINGS $SHOW_STDOUT tests_v2/"$*"
+docker-compose -f docker-compose.test.yml --project-name gfw-data-api_test run --rm --name app_test app_test --cov-report xml:/app/tests_v2/cobertura.xml $DO_COV $DISABLE_WARNINGS $SHOW_STDOUT $args
 exit_code=$?
 docker-compose -f docker-compose.test.yml --project-name gfw-data-api_test down --remove-orphans
 exit $exit_code

--- a/scripts/test_v2
+++ b/scripts/test_v2
@@ -6,6 +6,9 @@ set -e
 # Default values
 POSITIONAL=()
 BUILD=true
+DO_COV=
+DISABLE_WARNINGS="--disable-warnings"
+SHOW_STDOUT=
 # extracting cmd line arguments
 while [[ $# -gt 0 ]]
 do
@@ -16,12 +19,16 @@ do
       BUILD=false
       shift # past argument
       ;;
-      --without-hanging-tests)
-      HANGING=--without-hanging-tests
+      --do-cov)
+      DO_COV=--cov=app
       shift # past argument
       ;;
-      --with-slow-tests)
-      SLOW=--with-slow-tests
+      --show-warnings)
+      DISABLE_WARNINGS=
+      shift # past argument
+      ;;
+      --show-stdout)
+      SHOW_STDOUT=--capture=no
       shift # past argument
       ;;
       --moto-port=*)
@@ -38,7 +45,6 @@ do
 done
 set -- "${POSITIONAL[@]}" # restore positional parameters
 
-
 if [ "${BUILD}" = true ]; then
   docker build -t batch_gdal-python_test . -f batch/gdal-python.dockerfile
   docker build -t batch_postgresql-client_test . -f batch/postgresql-client.dockerfile
@@ -48,7 +54,9 @@ if [ "${BUILD}" = true ]; then
 fi
 
 set +e
-docker-compose -f docker-compose.test.yml --project-name gfw-data-api_test run --rm --name app_test app_test --cov-report xml:/app/tests_v2/cobertura.xml tests_v2/"$*"
+
+# Everything from "--cov-report on" become the arguments to the pytest run inside the docker.
+docker-compose -f docker-compose.test.yml --project-name gfw-data-api_test run --rm --name app_test app_test --cov-report xml:/app/tests_v2/cobertura.xml $DO_COV $DISABLE_WARNINGS $SHOW_STDOUT tests_v2/"$*"
 exit_code=$?
 docker-compose -f docker-compose.test.yml --project-name gfw-data-api_test down --remove-orphans
 exit $exit_code


### PR DESCRIPTION
GTC-2864 Make test output for Data API be less verbose

I changed both script/test and script/test_v2 to not show warnings or
do/show code coverage by default. So, the actual test results won't
scroll off the screen in the output when running a single or few tests.
Also, I added an option to cause stdout of the tests to be displayed, so
that you can see debugging print() calls when running tests, even if the
test succeeds. (Normally all output of a test is captured and not
displayed if the test succeeds, which makes sense when not debugging.)
    
New options (all off by default):
  --do-cov - Run code coverage and display it after the test results
 --show-warning - Show python warnings when compiling tests
  --show-stdout - Show output of successful tests

Definitely feel free to comment on other ways to improve the Data API test output.
