### PR TITLE
Fix loading geotrellis TSVs after package upgrades (agate, csvkit)

### DIFF
--- a/app/tasks/table_source_assets.py
+++ b/app/tasks/table_source_assets.py
@@ -39,7 +39,9 @@ async def table_source_asset(
         "-v",
         version,
         "-D",
-        creation_options.delimiter,
+        creation_options.delimiter.encode(
+            "unicode_escape"
+        ).decode(),  # Need to escape special characters such as TAB for batch job payload
         "-s",
         source_uris[0],
     ]

--- a/app/tasks/table_source_assets.py
+++ b/app/tasks/table_source_assets.py
@@ -38,6 +38,8 @@ async def table_source_asset(
         dataset,
         "-v",
         version,
+        "-D",
+        creation_options.delimiter,
         "-s",
         source_uris[0],
     ]

--- a/batch/gdal-python.dockerfile
+++ b/batch/gdal-python.dockerfile
@@ -1,4 +1,4 @@
-FROM globalforestwatch/data-api-gdal:v1.2.0
+FROM globalforestwatch/data-api-gdal:v1.2.1
 
 # Copy scripts
 COPY ./batch/scripts/ /opt/scripts/

--- a/batch/postgresql-client.dockerfile
+++ b/batch/postgresql-client.dockerfile
@@ -1,4 +1,4 @@
-FROM globalforestwatch/data-api-postgresql:v1.1.0
+FROM globalforestwatch/data-api-postgresql:v1.1.0a
 
 # Copy scripts
 COPY ./batch/scripts/ /opt/scripts/

--- a/batch/postgresql-client.dockerfile
+++ b/batch/postgresql-client.dockerfile
@@ -1,4 +1,4 @@
-FROM globalforestwatch/data-api-postgresql:v1.1.0a
+FROM globalforestwatch/data-api-postgresql:v1.1.1
 
 # Copy scripts
 COPY ./batch/scripts/ /opt/scripts/

--- a/batch/scripts/create_tabular_schema.sh
+++ b/batch/scripts/create_tabular_schema.sh
@@ -6,6 +6,7 @@ set -e
 # -d | --dataset
 # -v | --version
 # -s | --source
+# -D | --delimiter
 
 # optional arguments
 # -p | --partition_type
@@ -26,7 +27,7 @@ fi
 # expected and can be ignored, so temporarily use set +e here. HOWEVER we
 # still want to know if csvsql had a problem, so check its exit status
 set +e
-aws s3 cp "${SRC}" - | head -100 | csvsql -i postgresql --no-constraints $UNIQUE_CONSTRAINT --tables "$VERSION" -q \" > create_table.sql
+aws s3 cp "${SRC}" - | head -100 | csvsql -d "$(echo \'$DELIMITER\')" -i postgresql --no-constraints $UNIQUE_CONSTRAINT --tables "$VERSION" -q \" > create_table.sql
 CSVSQL_EXIT_CODE="${PIPESTATUS[2]}"  # Grab the exit code of the csvsql command
 set -e
 

--- a/batch/scripts/create_tabular_schema.sh
+++ b/batch/scripts/create_tabular_schema.sh
@@ -22,12 +22,17 @@ if [[ -n "${UNIQUE_CONSTRAINT_COLUMN_NAMES}" ]]; then
   UNIQUE_CONSTRAINT="--unique-constraint ${UNIQUE_CONSTRAINT_COLUMN_NAMES}"
 fi
 
+# Unescape TAB character
+if [ "$DELIMITER" == "\t" ]; then
+  DELIMITER=$(echo -e "\t")
+fi
+
 # Fetch first 100 lines from CSV, analyze and create table create statement
 # The `head` command will cause a broken pipe error for `aws s3 cp`: This is
 # expected and can be ignored, so temporarily use set +e here. HOWEVER we
 # still want to know if csvsql had a problem, so check its exit status
 set +e
-aws s3 cp "${SRC}" - | head -100 | csvsql -d "$(echo -e $DELIMITER)" -i postgresql --no-constraints $UNIQUE_CONSTRAINT --tables "$VERSION" -q \" > create_table.sql
+aws s3 cp "${SRC}" - | head -100 | csvsql -d "$DELIMITER" -i postgresql --no-constraints $UNIQUE_CONSTRAINT --tables "$VERSION" -q \" > create_table.sql
 CSVSQL_EXIT_CODE="${PIPESTATUS[2]}"  # Grab the exit code of the csvsql command
 set -e
 

--- a/batch/scripts/create_tabular_schema.sh
+++ b/batch/scripts/create_tabular_schema.sh
@@ -27,7 +27,7 @@ fi
 # expected and can be ignored, so temporarily use set +e here. HOWEVER we
 # still want to know if csvsql had a problem, so check its exit status
 set +e
-aws s3 cp "${SRC}" - | head -100 | csvsql -d "$(echo \'$DELIMITER\')" -i postgresql --no-constraints $UNIQUE_CONSTRAINT --tables "$VERSION" -q \" > create_table.sql
+aws s3 cp "${SRC}" - | head -100 | csvsql -d "$(echo -e $DELIMITER)" -i postgresql --no-constraints $UNIQUE_CONSTRAINT --tables "$VERSION" -q \" > create_table.sql
 CSVSQL_EXIT_CODE="${PIPESTATUS[2]}"  # Grab the exit code of the csvsql command
 set -e
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [x] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
In recent package upgrades in our Batch images there was a breaking change for our Geotrellis TSV files.

Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Don't leave it up to csvkit/agate to infer the delimiter since we require the client to specify it anyways!


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
Thanks to @gtempus for finding this bug and working with me to fix it. I was trying to pin the dependency but he realized that we already request the delimiter but weren't using it at the create table stage.