### PR TITLE
Increase COG batch attempts to 5

### DIFF
--- a/app/models/pydantic/jobs.py
+++ b/app/models/pydantic/jobs.py
@@ -145,7 +145,7 @@ class GDALCOGJob(Job):
     vcpus = 8
     memory = 64000
     num_processes = 8
-    attempts = 2
+    attempts = 5
     attempt_duration_seconds = int(DEFAULT_JOB_DURATION * 1.5)
 
 


### PR DESCRIPTION
Increase COG batch attempts to 5

Should move it back up, now that Justin add code to save results of intermediate steps. We may need at least one attempt to make progress on each intermediate step, and there might be one or two attempts that are cut so short that they make no progress.
