### PR TITLE
Show associated error message in job info if status is 'error' for a OTF list request

### DIFF
--- a/app/models/pydantic/user_job.py
+++ b/app/models/pydantic/user_job.py
@@ -8,8 +8,9 @@ from .responses import Response
 
 class UserJob(BaseModel):
     job_id: UUID
-    job_link: Optional[str]
-    status: str = "pending"
+    job_link: Optional[str]   # Full URL to check the job status
+    status: str = "pending"   # Can be pending, success, partial_success, failure, and error
+    message: Optional[str]    # Error message when status is "error"
     download_link: Optional[str] = None
     failed_geometries_link: Optional[str] = None
     progress: Optional[str] = "0%"

--- a/app/routes/jobs/job.py
+++ b/app/routes/jobs/job.py
@@ -68,7 +68,8 @@ async def _get_user_job(job_id: UUID) -> UserJob:
             logger.error(f"Analysis service returned an unexpected response: {output}")
             return UserJob(
                 job_id=job_id,
-                status="failed",
+                status="error",
+                message=output["message"],
                 download_link=None,
                 failed_geometries_link=None,
                 progress="0%",


### PR DESCRIPTION
We need to grab the error message out of the step function output, and return it
in the UserJob and UserJobResponse.