### PR TITLE
Handle case in _get_progress where map runs haven't started yet

### DIFF
--- a/app/routes/jobs/job.py
+++ b/app/routes/jobs/job.py
@@ -109,12 +109,18 @@ async def _get_sfn_execution(job_id: UUID) -> Dict[str, Any]:
 
 async def _get_progress(execution: Dict[str, Any]) -> str:
     map_run = await _get_map_run(execution)
+    if len(map_run) == 0:
+        # No map runs have started yet
+        return "0%"
     success_ratio = map_run["itemCounts"]["succeeded"] / map_run["itemCounts"]["total"]
     return f"{round(success_ratio * 100)}%"
 
 
 async def _get_map_run(execution: Dict[str, Any]) -> Dict[str, Any]:
-    map_runs = get_sfn_client().list_map_runs(executionArn=execution["executionArn"])
-    map_run_arn = map_runs["mapRuns"][0]["mapRunArn"]
+    map_runs = get_sfn_client().list_map_runs(executionArn=execution["executionArn"])["mapRuns"]
+    if len(map_runs) == 0:
+        # No map runs have started yet, return empty dict
+        return {}
+    map_run_arn = map_runs[0]["mapRunArn"]
     map_run = get_sfn_client().describe_map_run(mapRunArn=map_run_arn)
     return map_run


### PR DESCRIPTION
Handle case in _get_progress where map runs haven't started yet

If we're still in pre-processing, the map runs haven't started yet, so we need to deal with case where there are no map run entries yet, else there will be an exception/Internal Server Error.

