### PR TITLE
Restore behaviour of naming VTC layers after dataset

### DIFF
--- a/batch/scripts/create_vector_tile_cache.sh
+++ b/batch/scripts/create_vector_tile_cache.sh
@@ -18,7 +18,7 @@ ME=$(basename "$0")
 . get_arguments.sh "$@"
 
 
-NDJSON_FILE="data.json"
+NDJSON_FILE="${DATASET}.json"
 
 # Build an array of arguments to pass to tippecanoe
 TIPPE_ARG_ARRAY=(
@@ -28,6 +28,7 @@ TIPPE_ARG_ARRAY=(
   "--preserve-input-order"
   "-P"
   "-n" "${DATASET}"
+  "-l" "${DATASET}"
 )
 
 case ${TILE_STRATEGY} in


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [x] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
- All vector tile cache layers were being named "data" instead of after the dataset name

Issue Number: GTC-2949


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- All vector tile cache layers are named after the dataset name. Possibly not what we want in the end, but this was the previous behavior, which people expect

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
- Actually, we weren't specifying the layer name before, tippecanoe was using the dataset name because that's what we named the JSON file after. It looks like we DO allow clients to specify a layer name, but ignore it. But that's another ticket...