### PR TITLE
GTC-2958 Fix reference to non-existent ECR image

### DIFF
--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -37,7 +37,7 @@ data "terraform_remote_state" "tile_cache" {
 data "template_file" "container_definition" {
   template = file("${path.root}/templates/container_definition.json.tmpl")
   vars = {
-    image = "${module.app_docker_image.repository_url}:${local.container_tag}"
+    image = "${module.app_docker_image.repository_url}:latest"
 
     container_name = var.container_name
     container_port = var.container_port


### PR DESCRIPTION
The container_registry terraform module has the functionality that it will create a new docker image with the specified tag, but only if the docker contents have changed (as computed by its hash script, which understands .dockerignore, etc.)

We use as a container tag the git SHA, which is always different when we deploy a change. But if only terraform is being changed, no new docker image will be created, so there will be no image with that tag, leading to the bug.

Since the ECR registries are separated by GFW account, and within GFW-dev by the terraform.workspace name (branch), I believe we can instead change our tag reference in data.tf:template_file.container_definition to "latest" (which always exists), rather than the GIT sha tag, which may not exist.

Other possible solutions:
 - always create a new docker image for every GIT change
 - make the container tag be the MD5 of the docker contents, which would mean replicating the hash script in gfw-data-api, so we can compute it ahead of time.  Then we would always refer to a tag of an image that already exists or was just created.
