### PR TITLE
GTC-2904: Datamart Endpoint

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -20,6 +20,7 @@ from .routes import health
 from .routes.analysis import analysis
 from .routes.assets import asset, assets
 from .routes.authentication import authentication
+from .routes.datamart import globalforestwatch
 from .routes.datasets import asset as version_asset
 from .routes.datasets import (
     dataset,
@@ -33,7 +34,6 @@ from .routes.datasets import (
 from .routes.geostore import geostore as geostore_top
 from .routes.jobs import job
 from .routes.tasks import task
-from .routes.datamart import globalforestwatch
 
 ################
 # LOGGING
@@ -202,7 +202,7 @@ tags_metadata = [
     {"name": "Download", "description": downloads.__doc__},
     {"name": "Geostore", "description": geostore.__doc__},
     {"name": "Tasks", "description": task.__doc__},
-    {"name": "Analysis", "description": analysis.__doc__},
+    {"name": "Analysis2", "description": analysis.__doc__},
     {"name": "Job", "description": job.__doc__},
     {"name": "Health", "description": health.__doc__},
     {"name": "Data Mart", "description": globalforestwatch.__doc__},

--- a/app/main.py
+++ b/app/main.py
@@ -20,7 +20,7 @@ from .routes import health
 from .routes.analysis import analysis
 from .routes.assets import asset, assets
 from .routes.authentication import authentication
-from .routes.datamart import globalforestwatch
+from app.routes.datamart.analysis.forest_change import tree_cover_change
 from .routes.datasets import asset as version_asset
 from .routes.datasets import (
     dataset,
@@ -168,7 +168,7 @@ for r in analysis_routers:
 # Data Mart API
 ###############
 
-app.include_router(globalforestwatch.router, prefix="/datamart/globalforestwatch")
+app.include_router(tree_cover_change.router, prefix="/datamart/analysis/forest_change/tree_cover_change")
 
 ###############
 # JOB API
@@ -205,7 +205,7 @@ tags_metadata = [
     {"name": "Analysis2", "description": analysis.__doc__},
     {"name": "Job", "description": job.__doc__},
     {"name": "Health", "description": health.__doc__},
-    {"name": "Data Mart", "description": globalforestwatch.__doc__},
+    {"name": "Forest Change", "description": tree_cover_change.__doc__},
 ]
 
 
@@ -231,7 +231,7 @@ def custom_openapi():
         {"name": "Task API", "tags": ["Tasks"]},
         {"name": "Analysis API", "tags": ["Analysis"]},
         {"name": "Health API", "tags": ["Health"]},
-        {"name": "Data Mart API", "tags": ["Data Mart"]},
+        {"name": "Data Mart API", "tags": ["Forest Change"]},
     ]
 
     app.openapi_schema = openapi_schema

--- a/app/main.py
+++ b/app/main.py
@@ -33,6 +33,7 @@ from .routes.datasets import (
 from .routes.geostore import geostore as geostore_top
 from .routes.jobs import job
 from .routes.tasks import task
+from .routes.datamart import globalforestwatch
 
 ################
 # LOGGING
@@ -164,6 +165,12 @@ for r in analysis_routers:
 
 
 ###############
+# Data Mart API
+###############
+
+app.include_router(globalforestwatch.router, prefix="/datamart/globalforestwatch")
+
+###############
 # JOB API
 ###############
 
@@ -198,6 +205,7 @@ tags_metadata = [
     {"name": "Analysis", "description": analysis.__doc__},
     {"name": "Job", "description": job.__doc__},
     {"name": "Health", "description": health.__doc__},
+    {"name": "Data Mart", "description": globalforestwatch.__doc__},
 ]
 
 
@@ -223,6 +231,7 @@ def custom_openapi():
         {"name": "Task API", "tags": ["Tasks"]},
         {"name": "Analysis API", "tags": ["Analysis"]},
         {"name": "Health API", "tags": ["Health"]},
+        {"name": "Data Mart API", "tags": ["Data Mart"]},
     ]
 
     app.openapi_schema = openapi_schema

--- a/app/main.py
+++ b/app/main.py
@@ -13,6 +13,7 @@ from fastapi.staticfiles import StaticFiles
 from starlette.middleware.base import BaseHTTPMiddleware
 
 from app.errors import http_error_handler
+from app.routes.datamart import data_mart_router, datamart_metadata_tags
 
 from .application import app
 from .middleware import no_cache_response_header, redirect_latest, set_db_mode
@@ -20,7 +21,6 @@ from .routes import health
 from .routes.analysis import analysis
 from .routes.assets import asset, assets
 from .routes.authentication import authentication
-from app.routes.datamart.analysis.forest_change import tree_cover_change
 from .routes.datasets import asset as version_asset
 from .routes.datasets import (
     dataset,
@@ -168,7 +168,7 @@ for r in analysis_routers:
 # Data Mart API
 ###############
 
-app.include_router(tree_cover_change.router, prefix="/datamart/analysis/forest_change/tree_cover_change")
+app.include_router(data_mart_router)
 
 ###############
 # JOB API
@@ -202,11 +202,12 @@ tags_metadata = [
     {"name": "Download", "description": downloads.__doc__},
     {"name": "Geostore", "description": geostore.__doc__},
     {"name": "Tasks", "description": task.__doc__},
-    {"name": "Analysis2", "description": analysis.__doc__},
+    {"name": "Analysis", "description": analysis.__doc__},
     {"name": "Job", "description": job.__doc__},
     {"name": "Health", "description": health.__doc__},
-    {"name": "Forest Change", "description": tree_cover_change.__doc__},
 ]
+
+tags_metadata.extend(datamart_metadata_tags)
 
 
 def custom_openapi():
@@ -231,7 +232,7 @@ def custom_openapi():
         {"name": "Task API", "tags": ["Tasks"]},
         {"name": "Analysis API", "tags": ["Analysis"]},
         {"name": "Health API", "tags": ["Health"]},
-        {"name": "Data Mart API", "tags": ["Forest Change"]},
+        {"name": "Data Mart API", "tags": ["Forest Change Analysis 📊"]},
     ]
 
     app.openapi_schema = openapi_schema

--- a/app/routes/analysis/analysis.py
+++ b/app/routes/analysis/analysis.py
@@ -92,42 +92,6 @@ async def zonal_statistics_post(
     )
 
 
-
-@router.get(
-    "/datamart/net_tree_cover_change",
-    response_class=ORJSONResponse,
-    response_model=Response,
-    tags=["Analysis"],
-    deprecated=True,
-)
-async def zonal_statistics_get(
-    *,
-    iso: str = Query(..., title="ISO code"),
-    adm1: Optional[int] = Query(None, title="Admin level 1 ID"),
-    adm2: Optional[int] = Query(None, title="Admin level 2 ID"),
-):
-    select_fields = "iso, adm1, adm2, stable, loss, gain, disturb, net, change, gfw_area__ha"
-    where_filter = f"iso = '${iso}'"
-    level = "iso"
-
-    if adm1 is not None:
-        where_filter += f"AND adm1 = '${adm1}'"
-        level = "adm1"
-
-        if adm2 is not None:
-            where_filter += f"AND adm1 = '${adm2}'"
-            level = "adm2"
-
-
-    results = await _query_dataset_json(
-        dataset=f"umd_{level}_net_tree_cover_change_from_height",
-        version="v202209",
-        sql=f"SELECT ${select_fields} FROM data WHERE ${where_filter}",
-    )
-
-    return ORJSONResponse(data=results)
-
-
 async def _zonal_statistics(
     geometry: Geometry,
     sum_layers: List[RasterLayer],

--- a/app/routes/analysis/analysis.py
+++ b/app/routes/analysis/analysis.py
@@ -17,7 +17,7 @@ from ...models.pydantic.responses import Response
 from ...settings.globals import GEOSTORE_SIZE_LIMIT_OTF
 from ...utils.geostore import get_geostore
 from .. import DATE_REGEX
-from ..datasets.queries import _query_raster_lambda, _query_dataset_json
+from ..datasets.queries import _query_raster_lambda
 
 router = APIRouter()
 

--- a/app/routes/datamart/__init__.py
+++ b/app/routes/datamart/__init__.py
@@ -1,0 +1,27 @@
+"""
+Data Mart APIs for Global Forest Watch (GFW) backend consumption.
+
+These APIs provide coarse-grained, tailored data services specifically designed to meet the needs of WRI frontend applications.
+The endpoints abstract away the complexities of querying datasets related to tree cover change, allowing applications to integrate and consume
+data efficiently and reliably.
+
+### Key Features:
+- Tailored queries for retrieving net tree cover change data from the GFW database.
+- Efficient data retrieval for ISO country codes and administrative regions.
+- Abstracts the SQL query generation process to simplify integration with applications.
+"""
+from fastapi import APIRouter
+
+from app.routes.datamart.analysis import analysis_router, datamart_analysis_metadata_tags
+
+datamart_metadata_tags = [
+    {"name": "Data Mart", "description": __doc__},
+]
+
+datamart_metadata_tags.extend(datamart_analysis_metadata_tags)
+
+data_mart_router = APIRouter(
+    prefix="/datamart"
+)
+
+data_mart_router.include_router(analysis_router)

--- a/app/routes/datamart/analysis/__init__.py
+++ b/app/routes/datamart/analysis/__init__.py
@@ -1,0 +1,16 @@
+from fastapi import APIRouter
+
+from app.routes.datamart.analysis.forest_change import forest_change_router, \
+    datamart_analysis_forest_change_metadata_tags
+
+datamart_analysis_metadata_tags = [
+    {"name": "Data Mart Analysis", "description": __doc__},
+]
+
+datamart_analysis_metadata_tags.extend(datamart_analysis_forest_change_metadata_tags)
+
+analysis_router = APIRouter(
+    prefix="/analysis"
+)
+
+analysis_router.include_router(forest_change_router)

--- a/app/routes/datamart/analysis/forest_change/__init__.py
+++ b/app/routes/datamart/analysis/forest_change/__init__.py
@@ -1,0 +1,27 @@
+"""
+Forest Change analysis tools!
+
+**Legend:**
+
+⚠️ = _Alerts_
+
+🔥 = _Fires_
+
+🌳 = _Tree Cover Change_
+
+----
+"""
+from fastapi import APIRouter
+
+from app.routes.datamart.analysis.forest_change.tree_cover_change import tree_cover_change_router
+
+datamart_analysis_forest_change_metadata_tags = [
+    {"name": "Forest Change Analysis 📊", "description": __doc__},
+]
+
+forest_change_router = APIRouter(
+    prefix="/forest_change",
+    tags=["Forest Change Analysis 📊"]
+)
+
+forest_change_router.include_router(tree_cover_change_router)

--- a/app/routes/datamart/analysis/forest_change/tree_cover_change.py
+++ b/app/routes/datamart/analysis/forest_change/tree_cover_change.py
@@ -1,23 +1,16 @@
 """
 Data Mart APIs for Global Forest Watch (GFW) backend consumption.
 
-These APIs provide coarse-grained, tailored data services specifically designed to meet the needs of the **Global Forest Watch (GFW)** backend infrastructure.
-The endpoints abstract away the complexities of querying datasets related to net tree cover change, allowing the GFW backend to integrate and consume
+These APIs provide coarse-grained, tailored data services specifically designed to meet the needs of WRI frontend applications.
+The endpoints abstract away the complexities of querying datasets related to tree cover change, allowing applications to integrate and consume
 data efficiently and reliably.
-
-### Intended Audience:
-This API is not designed for general public use. It is purpose-built for internal use by the GFW backend services and systems. The consumers of this
-API are expected to have an in-depth understanding of GFW's data models and query requirements.
 
 ### Key Features:
 - Tailored queries for retrieving net tree cover change data from the GFW database.
 - Efficient data retrieval for ISO country codes and administrative regions.
-- Abstracts the SQL query generation process to simplify integration with the backend.
+- Abstracts the SQL query generation process to simplify integration with applications.
 
 ### Usage:
-These endpoints are intended to be consumed programmatically by the GFW backend and are not optimized for external client-facing use. The data
-retrieved is intended to support GFW's internal applications and services.
-
 Specifically, it supports the [Net change in tree cover](https://www.globalforestwatch.org/map/country/BRA/14/?mainMap=eyJzaG93QW5hbHlzaXMiOnRydWV9&map=eyJjZW50ZXIiOnsibGF0IjotMy42MjgwNjcwOTUyMDc3NDc2LCJsbmciOi01Mi40NzQ4OTk5OTk5OTczMzR9LCJ6b29tIjo2LjA1NTQ1ODQ3NjM4NDE1LCJjYW5Cb3VuZCI6ZmFsc2UsImRhdGFzZXRzIjpbeyJkYXRhc2V0IjoiTmV0LUNoYW5nZS1TVEFHSU5HIiwib3BhY2l0eSI6MSwidmlzaWJpbGl0eSI6dHJ1ZSwibGF5ZXJzIjpbImZvcmVzdC1uZXQtY2hhbmdlIl19LHsiZGF0YXNldCI6InBvbGl0aWNhbC1ib3VuZGFyaWVzIiwibGF5ZXJzIjpbImRpc3B1dGVkLXBvbGl0aWNhbC1ib3VuZGFyaWVzIiwicG9saXRpY2FsLWJvdW5kYXJpZXMiXSwib3BhY2l0eSI6MSwidmlzaWJpbGl0eSI6dHJ1ZX1dfQ%3D%3D&mapMenu=eyJtZW51U2VjdGlvbiI6ImRhdGFzZXRzIiwiZGF0YXNldENhdGVnb3J5IjoiZm9yZXN0Q2hhbmdlIn0%3D) widget
 """
 from enum import Enum
@@ -159,7 +152,7 @@ async def _fetch_tree_cover_data(sql_query: str, level: str, api_key: str) -> Tr
             logger.error(f"API responded with status code {response.status_code}: {response.content}")
             raise Exception("Failed to fetch tree cover data.")
 
-        # Parse and validate the response data into TreeCoverData models
+        # Parse and validate the response data into a TreeCoverData model
         response_data = response.json().get("data", [])[0]
         return TreeCoverData(**response_data)
 
@@ -174,7 +167,7 @@ async def _get_tree_cover_data(gadm_specification: GadmSpecification, api_key: A
     "/v1/net_tree_cover_change",
     response_class=ORJSONResponse,
     response_model=NetTreeCoverChangeResponse,
-    tags=["Data Mart"],
+    tags=["Forest Change"],
     summary="Retrieve net tree cover change data",
     description="This endpoint provides data on net tree cover change by querying the Global Forest Watch (GFW) database.",
 )

--- a/app/routes/datamart/analysis/forest_change/tree_cover_change.py
+++ b/app/routes/datamart/analysis/forest_change/tree_cover_change.py
@@ -1,18 +1,3 @@
-"""
-Data Mart APIs for Global Forest Watch (GFW) backend consumption.
-
-These APIs provide coarse-grained, tailored data services specifically designed to meet the needs of WRI frontend applications.
-The endpoints abstract away the complexities of querying datasets related to tree cover change, allowing applications to integrate and consume
-data efficiently and reliably.
-
-### Key Features:
-- Tailored queries for retrieving net tree cover change data from the GFW database.
-- Efficient data retrieval for ISO country codes and administrative regions.
-- Abstracts the SQL query generation process to simplify integration with applications.
-
-### Usage:
-Specifically, it supports the [Net change in tree cover](https://www.globalforestwatch.org/map/country/BRA/14/?mainMap=eyJzaG93QW5hbHlzaXMiOnRydWV9&map=eyJjZW50ZXIiOnsibGF0IjotMy42MjgwNjcwOTUyMDc3NDc2LCJsbmciOi01Mi40NzQ4OTk5OTk5OTczMzR9LCJ6b29tIjo2LjA1NTQ1ODQ3NjM4NDE1LCJjYW5Cb3VuZCI6ZmFsc2UsImRhdGFzZXRzIjpbeyJkYXRhc2V0IjoiTmV0LUNoYW5nZS1TVEFHSU5HIiwib3BhY2l0eSI6MSwidmlzaWJpbGl0eSI6dHJ1ZSwibGF5ZXJzIjpbImZvcmVzdC1uZXQtY2hhbmdlIl19LHsiZGF0YXNldCI6InBvbGl0aWNhbC1ib3VuZGFyaWVzIiwibGF5ZXJzIjpbImRpc3B1dGVkLXBvbGl0aWNhbC1ib3VuZGFyaWVzIiwicG9saXRpY2FsLWJvdW5kYXJpZXMiXSwib3BhY2l0eSI6MSwidmlzaWJpbGl0eSI6dHJ1ZX1dfQ%3D%3D&mapMenu=eyJtZW51U2VjdGlvbiI6ImRhdGFzZXRzIiwiZGF0YXNldENhdGVnb3J5IjoiZm9yZXN0Q2hhbmdlIn0%3D) widget
-"""
 from enum import Enum
 from typing import Optional
 
@@ -27,7 +12,10 @@ from app.authentication.api_keys import get_api_key
 from app.models.orm.api_keys import ApiKey
 from app.models.pydantic.base import StrictBaseModel
 
-router = APIRouter()
+
+tree_cover_change_router = APIRouter(
+    prefix="/tree_cover_change"
+)
 
 
 class Gadm(str, Enum):
@@ -163,13 +151,16 @@ async def _get_tree_cover_data(gadm_specification: GadmSpecification, api_key: A
     return await _fetch_tree_cover_data(sql_query, admin_level, api_key)
 
 
-@router.get(
-    "/v1/net_tree_cover_change",
+@tree_cover_change_router.get(
+    "/net_tree_cover_change",
     response_class=ORJSONResponse,
     response_model=NetTreeCoverChangeResponse,
-    tags=["Forest Change"],
-    summary="Retrieve net tree cover change data",
-    description="This endpoint provides data on net tree cover change by querying the Global Forest Watch (GFW) database.",
+    summary="🌳 Net Tree Cover Change",
+    description="""
+    Retrieve net tree cover change data.
+    This endpoint provides data on net tree cover change by querying the Global Forest Watch (GFW) database. 
+    Specifically, it supports the [Net change in tree cover](https://www.globalforestwatch.org/map/country/BRA/14/?mainMap=eyJzaG93QW5hbHlzaXMiOnRydWV9&map=eyJjZW50ZXIiOnsibGF0IjotMy42MjgwNjcwOTUyMDc3NDc2LCJsbmciOi01Mi40NzQ4OTk5OTk5OTczMzR9LCJ6b29tIjo2LjA1NTQ1ODQ3NjM4NDE1LCJjYW5Cb3VuZCI6ZmFsc2UsImRhdGFzZXRzIjpbeyJkYXRhc2V0IjoiTmV0LUNoYW5nZS1TVEFHSU5HIiwib3BhY2l0eSI6MSwidmlzaWJpbGl0eSI6dHJ1ZSwibGF5ZXJzIjpbImZvcmVzdC1uZXQtY2hhbmdlIl19LHsiZGF0YXNldCI6InBvbGl0aWNhbC1ib3VuZGFyaWVzIiwibGF5ZXJzIjpbImRpc3B1dGVkLXBvbGl0aWNhbC1ib3VuZGFyaWVzIiwicG9saXRpY2FsLWJvdW5kYXJpZXMiXSwib3BhY2l0eSI6MSwidmlzaWJpbGl0eSI6dHJ1ZX1dfQ%3D%3D&mapMenu=eyJtZW51U2VjdGlvbiI6ImRhdGFzZXRzIiwiZGF0YXNldENhdGVnb3J5IjoiZm9yZXN0Q2hhbmdlIn0%3D) widget.
+    """,
 )
 async def net_tree_cover_change(
         iso: str = Query(..., description="ISO code of the country or region (e.g., 'BRA' for Brazil).", example="BRA"),

--- a/app/routes/datamart/globalforestwatch.py
+++ b/app/routes/datamart/globalforestwatch.py
@@ -1,4 +1,5 @@
 """APIs for Global Forest Watch data."""
+from enum import Enum
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -6,60 +7,157 @@ from fastapi.logger import logger
 from fastapi.openapi.models import APIKey
 from fastapi.responses import ORJSONResponse
 from httpx import AsyncClient
+from pydantic import Field, root_validator, ValidationError
 
 from app.authentication.api_keys import get_api_key
-from app.models.pydantic.responses import Response
+from app.models.pydantic.base import StrictBaseModel
 
 router = APIRouter()
 
-PRODUCTION_SERVICE_URI = "https://data-api.globalforestwatch.org"
-NET_CHANGE_VERSION = "v202209"
+
+class Gadm(str, Enum):
+    ISO = "iso"
+    ADM0 = "adm0"
+    ADM1 = "adm1"
+    ADM2 = "adm2"
+
+
+class NetTreeCoverChangeRequest(StrictBaseModel):
+    iso: str = Field(..., description="ISO code of the country or region (e.g., 'BRA' for Brazil).")
+    adm1: Optional[int] = Field(None, description="Admin level 1 ID (e.g., a state or province).")
+    adm2: Optional[int] = Field(None, description="Admin level 2 ID (e.g., a municipality). ⚠️ **Must be provided with adm1.**")
+
+    @root_validator
+    def check_adm1_adm2_dependency(cls, values):
+        """
+        Validates that adm2 is only provided if adm1 is also present.
+        Raises a validation error if adm2 is given without adm1.
+        """
+        print(values.keys())
+        adm1, adm2 = values.get('adm1'), values.get('adm2')
+        if adm2 is not None and adm1 is None:
+            raise ValueError("If 'adm2' is provided, 'adm1' must also be present.")
+        return values
+
+    def get_admin_level(self):
+        """
+        Determines the appropriate level ('adm0', 'adm1', or 'adm2') based on the presence of adm1 and adm2.
+        """
+        if self.adm2 is not None:
+            return Gadm.ADM2.value  # Return the Enum value 'adm2'
+        if self.adm1 is not None:
+            return Gadm.ADM1.value  # Return the Enum value 'adm1'
+        return Gadm.ADM0.value  # Default to 'adm0'
+
+
+class TreeCoverData(StrictBaseModel):
+    """
+    Model representing individual tree cover change data from the API.
+    """
+    iso: str = Field(..., description="ISO code of the country or region (e.g., 'BRA' for Brazil).")
+    adm1: Optional[int] = Field(None, description="Admin level 1 ID (e.g., a state or province).")
+    adm2: Optional[int] = Field(None, description="Admin level 2 ID (e.g., a municipality).")
+    stable: float = Field(..., description="The area of stable forest in hectares.")
+    loss: float = Field(..., description="The area of forest loss in hectares.")
+    gain: float = Field(..., description="The area of forest gain in hectares.")
+    disturb: float = Field(..., description="The area of forest disturbance in hectares.")
+    net: float = Field(..., description="The net change in forest cover in hectares (gain - loss).")
+    change: float = Field(..., description="The percentage change in forest cover.")
+    gfw_area__ha: float = Field(..., description="The total forest area in hectares.")
+
+
+class NetTreeCoverChangeResponse(StrictBaseModel):
+    data: TreeCoverData = Field(..., description="A list of tree cover change data records.")
+    status: str = Field(..., description="Status of the request (e.g., 'success').")
+
+    class Config:
+        schema_extra = {
+            "example": {
+                "data":
+                    {
+                        "iso": "BRA",
+                        "stable": 413722809.3,
+                        "loss": 36141245.77,
+                        "gain": 8062324.946,
+                        "disturb": 23421628.86,
+                        "net": -28078920.83,
+                        "change": -5.932759761810303,
+                        "gfw_area__ha": 850036547.481532,
+                        "adm1": 12,
+                        "adm2": 34
+                    },
+                "status": "success"
+            }
+        }
+
+
+def build_sql_query(request):
+    select_fields = [Gadm.ISO.value]
+    where_conditions = [f"{Gadm.ISO.value} = '{request.iso}'"]
+
+    append_field_and_condition(select_fields, where_conditions, Gadm.ADM1.value, request.adm1)
+    append_field_and_condition(select_fields, where_conditions, Gadm.ADM2.value, request.adm2)
+
+    select_fields += ["stable", "loss", "gain", "disturb", "net", "change", "gfw_area__ha"]
+
+    select_fields_str = ", ".join(select_fields)
+    where_filter_str = " AND ".join(where_conditions)
+
+    sql = f"SELECT {select_fields_str} FROM data WHERE {where_filter_str}"
+
+    return sql
+
+def append_field_and_condition(select_fields, where_conditions, field_name, field_value):
+    if field_value is not None:
+        select_fields.append(field_name)
+        where_conditions.append(f"{field_name} = '{field_value}'")
+
+
+async def fetch_tree_cover_data(sql_query: str, level: str, api_key: str) -> TreeCoverData:
+    """
+    Fetches tree cover data from the external API using the SQL query and level.
+    Handles the HTTP request, response status check, and data extraction.
+    """
+    production_service_uri = "https://data-api.globalforestwatch.org"
+    net_change_version = "v202209"
+    url = f"{production_service_uri}/dataset/umd_{level}_net_tree_cover_change_from_height/{net_change_version}/query/json?sql={sql_query}"
+
+    async with AsyncClient() as client:
+        response = await client.get(url, headers={"x-api-key": api_key})
+        if response.status_code != 200:
+            logger.error(f"API responded with status code {response.status_code}: {response.content}")
+            raise Exception("Failed to fetch tree cover data.")
+
+        # Parse and validate the response data into TreeCoverData models
+        response_data = response.json().get("data", [])[0]
+        return TreeCoverData(**response_data)
 
 
 @router.get(
     "/v1/net_tree_cover_change",
     response_class=ORJSONResponse,
-    response_model=Response,
+    response_model=NetTreeCoverChangeResponse,
     tags=["Data Mart"],
+    summary="Retrieve net tree cover change data",
+    description="This endpoint provides data on net tree cover change by querying the Global Forest Watch (GFW) database.",
 )
 async def net_tree_cover_change(
-    *,
-    iso: str = Query(..., title="ISO code"),
-    adm1: Optional[int] = Query(None, title="Admin level 1 ID"),
-    adm2: Optional[int] = Query(None, title="Admin level 2 ID"),
-    api_key: APIKey = Depends(get_api_key),
+        iso: str = Query(..., description="ISO code of the country or region (e.g., 'BRA' for Brazil).", example="BRA"),
+        adm1: Optional[int] = Query(None, description="Admin level 1 ID (e.g., a state or province).", example="12"),
+        adm2: Optional[int] = Query(None, description="Admin level 2 ID (e.g., a municipality). ⚠️ **Must provide `adm1` also.**", example="34"),
+        api_key: APIKey = Depends(get_api_key)
 ):
-    select_fields = "iso"
-    where_filter = f"iso = '{iso}'"
-    level = "adm0"
+    """
+    Retrieves net tree cover change data.
+    """
+    try:
+        request = NetTreeCoverChangeRequest(iso=iso, adm1=adm1, adm2=adm2)
+        sql_query: str = build_sql_query(request)
+        admin_level: str = request.get_admin_level()
+        tree_cover_data: TreeCoverData = await fetch_tree_cover_data(sql_query, admin_level, api_key)
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e))
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
 
-    if adm1 is not None:
-        where_filter += f"AND adm1 = '{adm1}'"
-        select_fields += ", adm1"
-        level = "adm1"
-
-        if adm2 is not None:
-            where_filter += f"AND adm2 = '{adm2}'"
-            select_fields += ", adm2"
-            level = "adm2"
-    elif adm2 is not None:
-        raise HTTPException(
-            400, "If query for adm2, you must also include an adm1 parameter."
-        )
-
-    select_fields += ", stable, loss, gain, disturb, net, change, gfw_area__ha"
-
-    async with AsyncClient() as client:
-        sql = f"SELECT {select_fields} FROM data WHERE {where_filter}"
-        url = f"{PRODUCTION_SERVICE_URI}/dataset/umd_{level}_net_tree_cover_change_from_height/{NET_CHANGE_VERSION}/query/json?sql={sql}"
-
-        response = await client.get(url, headers={"x-api-key": api_key})
-        if response.status_code != 200:
-            logger.error(
-                f"API responded with status code {response.status_code}: {response.content}"
-            )
-            raise HTTPException(500, "Internal Server Error")
-
-        results = response.json()["data"]
-
-    return Response(data=results)
+    return NetTreeCoverChangeResponse(data=tree_cover_data, status="success")

--- a/app/routes/datamart/globalforestwatch.py
+++ b/app/routes/datamart/globalforestwatch.py
@@ -88,7 +88,7 @@ class TreeCoverData(StrictBaseModel):
 
 
 class NetTreeCoverChangeResponse(StrictBaseModel):
-    data: TreeCoverData = Field(..., description="A list of tree cover change data records.")
+    data: TreeCoverData = Field(..., description="A tree cover change data record.")
     status: str = Field(..., description="Status of the request (e.g., 'success').")
 
     class Config:

--- a/app/routes/datamart/globalforestwatch.py
+++ b/app/routes/datamart/globalforestwatch.py
@@ -1,0 +1,58 @@
+"""APIs for Global Forest Watch data."""
+
+from typing import Optional
+
+from fastapi import Query, APIRouter, HTTPException
+from fastapi.logger import logger
+from fastapi.responses import ORJSONResponse
+from httpx import AsyncClient
+
+from app.models.pydantic.responses import Response
+
+router = APIRouter()
+
+PRODUCTION_SERVICE_URI = "https://data-api.globalforestwatch.org"
+NET_CHANGE_VERSION = "v202209"
+
+@router.get(
+    "/v1/net_tree_cover_change",
+    response_class=ORJSONResponse,
+    response_model=Response,
+    tags=["Data Mart"],
+)
+async def net_tree_cover_change(
+    *,
+    iso: str = Query(..., title="ISO code"),
+    adm1: Optional[int] = Query(None, title="Admin level 1 ID"),
+    adm2: Optional[int] = Query(None, title="Admin level 2 ID"),
+):
+    select_fields = "iso"
+    where_filter = f"iso = '{iso}'"
+    level = "adm0"
+
+    if adm1 is not None:
+        where_filter += f"AND adm1 = '{adm1}'"
+        select_fields += ", adm1"
+        level = "adm1"
+
+        if adm2 is not None:
+            where_filter += f"AND adm2 = '{adm2}'"
+            select_fields += ", adm2"
+            level = "adm2"
+    elif adm2 is not None:
+        raise HTTPException(400, "If query for adm2, you must also include an adm1 parameter.")
+
+    select_fields += ", stable, loss, gain, disturb, net, change, gfw_area__ha"
+
+    async with AsyncClient() as client:
+        sql = f"SELECT {select_fields} FROM data WHERE {where_filter}"
+        url = f"{PRODUCTION_SERVICE_URI}/dataset/umd_{level}_net_tree_cover_change_from_height/{NET_CHANGE_VERSION}/query/json?sql={sql}"
+
+        response = await client.get(url)
+        if response.status_code != 200:
+            logger.error(f"API responded with status code {response.status_code}: {response.content}")
+            raise HTTPException(500, "Internal Server Error")
+
+        results = response.json()["data"]
+
+    return Response(data=results)

--- a/app/routes/datamart/globalforestwatch.py
+++ b/app/routes/datamart/globalforestwatch.py
@@ -1,4 +1,25 @@
-"""APIs for Global Forest Watch data."""
+"""
+Data Mart APIs for Global Forest Watch (GFW) backend consumption.
+
+These APIs provide granular, tailored data services specifically designed to meet the needs of the **Global Forest Watch (GFW)** backend infrastructure.
+The endpoints abstract away the complexities of querying datasets related to net tree cover change, allowing the GFW backend to integrate and consume
+data efficiently and reliably.
+
+### Intended Audience:
+This API is not designed for general public use. It is purpose-built for internal use by the GFW backend services and systems. The consumers of this
+API are expected to have an in-depth understanding of GFW's data models and query requirements.
+
+### Key Features:
+- Tailored queries for retrieving net tree cover change data from the GFW database.
+- Efficient data retrieval for ISO country codes and administrative regions.
+- Abstracts the SQL query generation process to simplify integration with the backend.
+
+### Usage:
+These endpoints are intended to be consumed programmatically by the GFW backend and are not optimized for external client-facing use. The data
+retrieved is intended to support GFW's internal applications and services.
+
+Specifically, it supports the [Net change in tree cover](https://www.globalforestwatch.org/map/country/BRA/14/?mainMap=eyJzaG93QW5hbHlzaXMiOnRydWV9&map=eyJjZW50ZXIiOnsibGF0IjotMy42MjgwNjcwOTUyMDc3NDc2LCJsbmciOi01Mi40NzQ4OTk5OTk5OTczMzR9LCJ6b29tIjo2LjA1NTQ1ODQ3NjM4NDE1LCJjYW5Cb3VuZCI6ZmFsc2UsImRhdGFzZXRzIjpbeyJkYXRhc2V0IjoiTmV0LUNoYW5nZS1TVEFHSU5HIiwib3BhY2l0eSI6MSwidmlzaWJpbGl0eSI6dHJ1ZSwibGF5ZXJzIjpbImZvcmVzdC1uZXQtY2hhbmdlIl19LHsiZGF0YXNldCI6InBvbGl0aWNhbC1ib3VuZGFyaWVzIiwibGF5ZXJzIjpbImRpc3B1dGVkLXBvbGl0aWNhbC1ib3VuZGFyaWVzIiwicG9saXRpY2FsLWJvdW5kYXJpZXMiXSwib3BhY2l0eSI6MSwidmlzaWJpbGl0eSI6dHJ1ZX1dfQ%3D%3D&mapMenu=eyJtZW51U2VjdGlvbiI6ImRhdGFzZXRzIiwiZGF0YXNldENhdGVnb3J5IjoiZm9yZXN0Q2hhbmdlIn0%3D) widget
+"""
 from enum import Enum
 from typing import Optional
 

--- a/app/routes/datamart/globalforestwatch.py
+++ b/app/routes/datamart/globalforestwatch.py
@@ -1,7 +1,7 @@
 """
 Data Mart APIs for Global Forest Watch (GFW) backend consumption.
 
-These APIs provide granular, tailored data services specifically designed to meet the needs of the **Global Forest Watch (GFW)** backend infrastructure.
+These APIs provide coarse-grained, tailored data services specifically designed to meet the needs of the **Global Forest Watch (GFW)** backend infrastructure.
 The endpoints abstract away the complexities of querying datasets related to net tree cover change, allowing the GFW backend to integrate and consume
 data efficiently and reliably.
 

--- a/tests_v2/unit/app/routes/datamart/analysis/forest_change/test_net_tree_cover_change.py
+++ b/tests_v2/unit/app/routes/datamart/analysis/forest_change/test_net_tree_cover_change.py
@@ -33,7 +33,7 @@ async def send_tree_cover_change_request(api_key, async_client: AsyncClient, par
 
 
 @pytest.mark.asyncio
-async def test_net_tree_cover_change_builds_succeeds(
+async def test_net_tree_cover_change_succeeds(
         apikey, async_client: AsyncClient
 ):
     with patch(

--- a/tests_v2/unit/app/routes/datamart/analysis/forest_change/test_net_tree_cover_change.py
+++ b/tests_v2/unit/app/routes/datamart/analysis/forest_change/test_net_tree_cover_change.py
@@ -1,0 +1,181 @@
+from unittest.mock import AsyncMock, patch, ANY
+from fastapi import status
+import pytest
+from httpx import AsyncClient
+
+from app.routes.datamart.analysis.forest_change.tree_cover_change import TreeCoverData
+
+# Define the stubbed response for _fetch_tree_cover_data so the route is successful
+stubbed_tree_cover_data = TreeCoverData(
+    iso="BRA",
+    adm1=12,
+    adm2=34,
+    stable=413722809.3,
+    loss=36141245.77,
+    gain=8062324.946,
+    disturb=23421628.86,
+    net=-28078920.83,
+    change=-5.932759761810303,
+    gfw_area__ha=850036547.481532
+)
+
+
+# Common helper function to send the request
+async def send_tree_cover_change_request(api_key, async_client: AsyncClient, params):
+    headers = {"x-api-key": api_key}
+    response = await async_client.get(
+        f"/datamart/analysis/forest_change/tree_cover_change/net_tree_cover_change",
+        params=params,
+        headers=headers,
+        follow_redirects=True,
+    )
+    return response
+
+
+@pytest.mark.asyncio
+async def test_net_tree_cover_change_builds_succeeds(
+        apikey, async_client: AsyncClient
+):
+    with patch(
+            "app.routes.datamart.analysis.forest_change.tree_cover_change._fetch_tree_cover_data",
+            AsyncMock(return_value=stubbed_tree_cover_data)
+    ):
+        api_key, payload = apikey
+        params = {"iso": "BRA"}
+
+        response = await send_tree_cover_change_request(api_key, async_client, params)
+
+        assert response.status_code == status.HTTP_200_OK, "Expected status code 200 OK"
+
+
+@pytest.mark.asyncio
+class TestSQLBuilding:
+    @pytest.mark.asyncio
+    async def test_net_tree_cover_change_builds_sql_with_iso(self, apikey, async_client: AsyncClient):
+        with patch(
+                "app.routes.datamart.analysis.forest_change.tree_cover_change._fetch_tree_cover_data",
+                AsyncMock(return_value=stubbed_tree_cover_data)
+        ) as mock_fetch:
+            api_key, payload = apikey
+            params = {"iso": "BRA"}
+
+            await send_tree_cover_change_request(api_key, async_client, params)
+
+            mock_fetch.assert_called_once_with(
+                "SELECT iso, stable, loss, gain, disturb, net, change, gfw_area__ha FROM data WHERE iso = 'BRA'",
+                # SQL query
+                ANY,  # Ignore admin level
+                ANY  # Ignore API Key
+            )
+
+
+    @pytest.mark.asyncio
+    async def test_net_tree_cover_change_builds_sql_with_adm1(self, apikey, async_client: AsyncClient):
+        with patch(
+                "app.routes.datamart.analysis.forest_change.tree_cover_change._fetch_tree_cover_data",
+                AsyncMock(return_value=stubbed_tree_cover_data)
+        ) as mock_fetch:
+            api_key, payload = apikey
+            params = {"iso": "BRA", "adm1": 12}
+
+            await send_tree_cover_change_request(api_key, async_client, params)
+
+            mock_fetch.assert_called_once_with(
+                "SELECT iso, adm1, stable, loss, gain, disturb, net, change, gfw_area__ha FROM data WHERE iso = 'BRA' AND adm1 = '12'",
+                # SQL query
+                ANY,  # Ignore admin level
+                ANY  # Ignore API Key
+            )
+
+
+    @pytest.mark.asyncio
+    async def test_net_tree_cover_change_builds_sql_with_adm2(self, apikey, async_client: AsyncClient):
+        with patch(
+                "app.routes.datamart.analysis.forest_change.tree_cover_change._fetch_tree_cover_data",
+                AsyncMock(return_value=stubbed_tree_cover_data)
+        ) as mock_fetch:
+            api_key, payload = apikey
+            params = {"iso": "BRA", "adm1": 12, "adm2": 34}
+
+            await send_tree_cover_change_request(api_key, async_client, params)
+
+            mock_fetch.assert_called_once_with(
+                "SELECT iso, adm1, adm2, stable, loss, gain, disturb, net, change, gfw_area__ha FROM data WHERE iso = 'BRA' AND adm1 = '12' AND adm2 = '34'",
+                # SQL query
+                ANY,  # Ignore admin level
+                ANY  # Ignore API Key
+            )
+
+
+@pytest.mark.asyncio
+class TestAdminLevel:
+    @pytest.mark.asyncio
+    async def test_net_tree_cover_change_passes_iso(self, apikey, async_client):
+        api_key, payload = apikey
+        with patch(
+                "app.routes.datamart.analysis.forest_change.tree_cover_change._fetch_tree_cover_data",
+                AsyncMock(return_value=stubbed_tree_cover_data)
+        ) as mock_fetch:
+            params = {"iso": "BRA"}
+
+            await send_tree_cover_change_request(api_key, async_client, params)
+
+            mock_fetch.assert_called_once_with(
+                ANY,  # Ignore SQL
+                'adm0',  # most precise adm level
+                ANY  # Ignore API Key
+            )
+
+    @pytest.mark.asyncio
+    async def test_net_tree_cover_change_passes_adm1(self, apikey, async_client):
+        api_key, payload = apikey
+        with patch(
+                "app.routes.datamart.analysis.forest_change.tree_cover_change._fetch_tree_cover_data",
+                AsyncMock(return_value=stubbed_tree_cover_data)
+        ) as mock_fetch:
+            params = {"iso": "BRA", "adm1": "12"}
+
+            await send_tree_cover_change_request(api_key, async_client, params)
+
+            mock_fetch.assert_called_once_with(
+                ANY,  # Ignore SQL
+                'adm1',  # most precise adm level
+                ANY  # Ignore API Key
+            )
+
+    @pytest.mark.asyncio
+    async def test_net_tree_cover_change_passes_adm2(self, apikey, async_client):
+        api_key, payload = apikey
+        with patch(
+                "app.routes.datamart.analysis.forest_change.tree_cover_change._fetch_tree_cover_data",
+                AsyncMock(return_value=stubbed_tree_cover_data)
+        ) as mock_fetch:
+            params = {"iso": "BRA", "adm1": "12", "adm2": "34"}
+
+            await send_tree_cover_change_request(api_key, async_client, params)
+
+            mock_fetch.assert_called_once_with(
+                ANY,  # Ignore SQL
+                'adm2',  # most precise adm level
+                ANY  # Ignore API Key
+            )
+
+
+@pytest.mark.asyncio
+async def test_net_tree_cover_change_passes_api_key(
+        apikey, async_client: AsyncClient
+):
+    with patch(
+            "app.routes.datamart.analysis.forest_change.tree_cover_change._fetch_tree_cover_data",
+            AsyncMock(return_value=stubbed_tree_cover_data)
+    ) as mock_fetch:
+        api_key, payload = apikey
+        params = {"iso": "BRA"}
+
+        await send_tree_cover_change_request(api_key, async_client, params)
+
+        mock_fetch.assert_called_once_with(
+            ANY,  # Ignore SQL
+            ANY,  # Ignore admin level
+            api_key  # api key
+        )


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [x] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

## Pull request type
Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): **This is a proof of concept (PoC). We don't want to merge this PR; only learn from it.**

## What is the current behavior?
### Coarse-grained vs. Fine-grained Services (Endpoints)
API clients must know how to use the fine-grained endpoints (query, etc) to query datasets with tedious SQL. This is great when you are doing ad-hoc work, but once a client settles on and becomes dependent on specific queries, a more coarse-grained endpoint should be created to serve their needs. [This Thoughtworks article](https://www.thoughtworks.com/en-us/insights/blog/rest-api-design-resource-modeling) explains the spirit of what a coarse-grained endpoint should be trying to accomplish.

Issue Number: [GTC-2904](https://gfw.atlassian.net/browse/GTC-2904)

## What is the new behavior?
This PoC introduces the concept of organized _services_ that are ready for consumption by various clients without needing to know the intricacies of our DB schema. The organization is inspired by Flagship's map navigation:

![organize_datamart](https://github.com/user-attachments/assets/6735a2f9-2e3b-47d6-aec9-2cd6cb358585)

## Testing
You can hit this endpoint using cURL:
```bash
curl --location 'http://gfw-data-api-elb-shared-dev-lb-10091095.us-east-1.elb.amazonaws.com:30616/datamart/analysis/forest_change/tree_cover_change/net_tree_cover_change?iso=BRA&x-api-key=<your_api-key>' \
--data ''
```

An example response:
```json
{
    "data": {
        "iso": "BRA",
        "adm1": null,
        "adm2": null,
        "stable": 413722809.3,
        "loss": 36141245.77,
        "gain": 8062324.946,
        "disturb": 23421628.86,
        "net": -28078920.83,
        "change": -5.932759761810303,
        "gfw_area__ha": 850036547.481532
    },
    "status": "success"
}
```

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
### Flagship Integration
The client of this endpoint can be reviewed in [this Flagship PR](https://github.com/wri/gfw/pull/4848). It demonstrates how much _business logic_ will be removed by embracing a coarse-grained approach.


[GTC-2904]: https://gfw.atlassian.net/browse/GTC-2904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ