### PR TITLE
Back out use of new pixetl docker using hard links to reduce disk space

### DIFF
--- a/batch/pixetl.dockerfile
+++ b/batch/pixetl.dockerfile
@@ -1,4 +1,4 @@
-FROM globalforestwatch/pixetl:v1.7.8rc2
+FROM globalforestwatch/pixetl:v1.7.7
 
 # Copy scripts
 COPY ./batch/scripts/ /opt/scripts/


### PR DESCRIPTION
I ran a full test using the DIST-Alerts, and it seems like the tile files are generally much smaller, so there could be a bug.
