### PR TITLE
Sort the assets by creation time in the version endpoint, just like /assets

### DIFF
--- a/app/routes/datasets/asset.py
+++ b/app/routes/datasets/asset.py
@@ -66,7 +66,8 @@ async def get_version_assets(
         description="The number of assets per page. Default is `10`.",
     ),
 ) -> Union[PaginatedAssetsResponse, AssetsResponse]:
-    """Get all assets for a given dataset version.
+    """Get all assets for a given dataset version. The list of assets
+    is sorted by the creation time of each asset.
 
     Will attempt to paginate if `page[size]` or `page[number]` is
     provided. Otherwise, it will attempt to return the entire list of

--- a/app/routes/datasets/versions.py
+++ b/app/routes/datasets/versions.py
@@ -536,6 +536,7 @@ async def _version_response(
         .where(ORMAsset.dataset == dataset)
         .where(ORMAsset.version == version)
         .where(ORMAsset.status == AssetStatus.saved)
+        .order_by(ORMAsset.created_on)
         .gino.all()
     )
     data = Version.from_orm(data).dict(by_alias=True)

--- a/app/routes/datasets/versions.py
+++ b/app/routes/datasets/versions.py
@@ -81,7 +81,8 @@ router = APIRouter()
 async def get_version(
     *, dv: Tuple[str, str] = Depends(dataset_version_dependency)
 ) -> VersionResponse:
-    """Get basic metadata for a given version."""
+    """Get basic metadata for a given version. The list of assets is sorted by
+    the creation time of each asset."""
 
     dataset, version = dv
     row: ORMVersion = await versions.get_version(dataset, version)


### PR DESCRIPTION
Sort the assets by creation time in the version endpoint, just like the /assets endpoint

We made the asset list in the GET version endpoint more useful recently by including the asset-id. But that list is not being sorted by creation time, unlike the list provided by /assets, so the assets are somewhat randomly ordered.

So, add the change to sort the asset list of the GET version endpoint by creation time. This ensures that the default asset is always first, etc. (same as the ordering in _build_filtered_query)
