### PR TITLE
GTC-3137 Fix extract_level_gid to deal with misformats in GADM 4.1

### DIFF
--- a/app/routes/political/id_lookup.py
+++ b/app/routes/political/id_lookup.py
@@ -165,4 +165,14 @@ def form_admin_id_lookup_response(
 
 def extract_level_gid(gid_level: int, match):
     gid_level_name = f"gid_{gid_level}"
-    return (match[gid_level_name].rsplit("_")[0]).split(".")[gid_level]
+    gid_str = match[gid_level_name]
+
+    # Exception because of bad formatting of GHA gids in gadm_administrative_boundaries/v4.1
+    if gid_str.startswith("GHA") and not gid_str.startswith("GHA."):
+        gid_str = "GHA." + gid_str[3:]
+    # Exception because bad ids IDN.35.4, IDN.35.8, IDN.35.9, IDN.35.13, IDN.35.14
+    # (they are missing final '_1') in gadm_administrative_boundaries/v4.1
+    if gid_str.startswith("IDN") and not gid_str.endswith("_1"):
+        gid_str += "_1"
+
+    return (gid_str.rsplit("_")[0]).split(".")[gid_level]


### PR DESCRIPTION
GTC-3137 Fix extract_level_gid to deal with misformats in GADM 4.1

Fix extract_level_gid to deal with misformatting of gids for Ghana and Indonesia in GADM 4.1. I just localized the fixes to a few lines in extract_level_gid, and the adjustments only happen if the gid is misformatted.

Added a few tests of extract_level_gid().

