### PR TITLE
GTC-2708 Fix deleting of the tile cache when deleting a version

### DIFF
--- a/app/tasks/aws_tasks.py
+++ b/app/tasks/aws_tasks.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional
 
 from botocore.exceptions import ClientError
@@ -89,11 +89,15 @@ def flush_cloudfront_cache(cloudfront_id: str, paths: List[str]) -> Dict[str, An
 def _expiration_rule(
     prefix: Optional[str] = None,
     key: Optional[str] = None,
-    value: Optional[str] = None,
-    expiration_date=datetime.utcnow(),
+    value: Optional[str] = None
 ) -> Dict[str, Any]:
     """Define S3 lifecycle rule which will delete all files with prefix
     dataset/version/ within 24h."""
+
+    # The specified expiration time must be at midnight UTC, so set it to midnight
+    # UTC of current date.
+    now_utc = datetime.utcnow()
+    expiration_date = datetime(now_utc.year, now_utc.month, now_utc.day, 0, 0, 0, 0, tzinfo=timezone.utc)
 
     if prefix and key and value:
         rule_filter: Dict[str, Any] = {
@@ -121,10 +125,17 @@ def _update_lifecycle_rule(bucket, rule) -> Dict[str, Any]:
     client = get_s3_client()
     rules = _get_lifecycle_rules(bucket)
     rules.append(rule)
-    logger.debug(f"Add lifecycle configuration rule {rules} to bucket {bucket}")
-    response = client.put_bucket_lifecycle_configuration(
-        Bucket=bucket, LifecycleConfiguration={"Rules": rules}
-    )
+    logger.info(f"Add lifecycle configuration rule {rules} to bucket {bucket}")
+    response = {}
+    try:
+        response = client.put_bucket_lifecycle_configuration(
+            Bucket=bucket, LifecycleConfiguration={"Rules": rules}
+        )
+    except Exception as e:
+        # Make sure to print out any exception, since this function is probably
+        # running in a background task, so any thrown exception may get lost.
+        logger.info(f"lifecycle exception {str(e)}, {e.__class__.__name__}, {e.args}")
+    logger.info(f"Response lifecycle {response}")
     return response
 
 

--- a/app/tasks/aws_tasks.py
+++ b/app/tasks/aws_tasks.py
@@ -134,7 +134,7 @@ def _update_lifecycle_rule(bucket, rule) -> Dict[str, Any]:
     except Exception as e:
         # Make sure to print out any exception, since this function is probably
         # running in a background task, so any thrown exception may get lost.
-        logger.info(f"lifecycle exception {str(e)}, {e.__class__.__name__}, {e.args}")
+        logger.warning(f"lifecycle exception {str(e)}, {e.__class__.__name__}, {e.args}")
     logger.info(f"Response lifecycle {response}")
     return response
 

--- a/app/tasks/delete_assets.py
+++ b/app/tasks/delete_assets.py
@@ -6,17 +6,17 @@ from ..settings.globals import (
 )
 from ..utils.path import split_s3_path
 from .aws_tasks import delete_s3_objects, expire_s3_objects, flush_cloudfront_cache
+from fastapi.logger import logger
 
 
 async def delete_all_assets(dataset: str, version: str) -> None:
     await delete_database_table_asset(dataset, version)
     delete_s3_objects(DATA_LAKE_BUCKET, f"{dataset}/{version}/")
 
-    # We don't yet have the correct PutBucketLifecycleConfiguration permission for
-    # this expire_s3_objects call. The failure of this background task somehow causes
-    # the main delete request to return a network error (504)
-    #expire_s3_objects(TILE_CACHE_BUCKET, f"{dataset}/{version}/")
+    expire_s3_objects(TILE_CACHE_BUCKET, f"{dataset}/{version}/")
     flush_cloudfront_cache(TILE_CACHE_CLOUDFRONT_ID, [f"/{dataset}/{version}/*"])
+    # Log to make sure we completed delete_all_assets without an exception.
+    logger.info("Finish delete_all_assets")
 
 
 async def delete_dynamic_vector_tile_cache_assets(

--- a/terraform/templates/tile_cache_bucket_policy.json.tmpl
+++ b/terraform/templates/tile_cache_bucket_policy.json.tmpl
@@ -5,7 +5,7 @@
             "Effect": "Allow",
             "Action": [
                 "s3:ListBucket",
-                "s3:PutBucketLifecycleConfiguration"
+                "s3:PutLifecycleConfiguration"
             ],
             "Resource": "${bucket_arn}"
         },


### PR DESCRIPTION
GTC-2708 Fix deleting of the tile cache when deleting a version

The main issue was that the correct lifecycle action permission is actually s3:PutLifecycleConfiguration, but we've always had s3:PutBucketLifecycleConfiguration in the policy templates.

A second issue is that the expiration time for a bucket/folder must be a date specified as midnight UTC. We were just using the current time, so that caused an error when trying to set the lifecycle rule.

In both cases, we weren't seeing the error, because delete_all_assets was called from a background task, so any exception was getting lost without being logged. So, I added a try-except around the call to put_bucket_lifecycle_configuration(), so we log future errors (and don't kill the task).

Given these fixes, I was able to re-enable the use of expire_s3_objects() and it worked!
