### PR TITLE
Various fixes for drivers endpoints

### DIFF
--- a/app/routes/datamart/land.py
+++ b/app/routes/datamart/land.py
@@ -31,7 +31,7 @@ router = APIRouter()
 
 
 @router.get(
-    "/tree-cover-loss-by-driver",
+    "/tree_cover_loss_by_driver",
     response_class=ORJSONResponse,
     response_model=DataMartResourceLinkResponse,
     tags=["Land"],
@@ -51,19 +51,19 @@ async def tree_cover_loss_by_driver_search(
     dataset_version = DEFAULT_LAND_DATASET_VERSIONS | query_dataset_version
 
     resource_id = _get_resource_id(
-        "tree-cover-loss-by-driver", geostore_id, canopy_cover, dataset_version
+        "tree_cover_loss_by_driver", geostore_id, canopy_cover, dataset_version
     )
 
     # check if it exists
     await _get_resource(resource_id)
     link = DataMartResourceLink(
-        link=f"{API_URL}/v0/land/tree-cover-loss-by-driver/{resource_id}"
+        link=f"{API_URL}/v0/land/tree_cover_loss_by_driver/{resource_id}"
     )
     return DataMartResourceLinkResponse(data=link)
 
 
 @router.get(
-    "/tree-cover-loss-by-driver/{resource_id}",
+    "/tree_cover_loss_by_driver/{resource_id}",
     response_class=ORJSONResponse,
     response_model=TreeCoverLossByDriverResponse,
     tags=["Land"],
@@ -94,7 +94,7 @@ async def tree_cover_loss_by_driver_get(
 
 
 @router.post(
-    "/tree-cover-loss-by-driver",
+    "/tree_cover_loss_by_driver",
     response_class=ORJSONResponse,
     response_model=DataMartResourceLinkResponse,
     tags=["Land"],
@@ -122,7 +122,7 @@ async def tree_cover_loss_by_driver_post(
     # return 202 accepted
     dataset_version = DEFAULT_LAND_DATASET_VERSIONS | data.dataset_version
     resource_id = _get_resource_id(
-        "tree-cover-loss-by-driver",
+        "tree_cover_loss_by_driver",
         data.geostore_id,
         data.canopy_cover,
         dataset_version,
@@ -139,7 +139,7 @@ async def tree_cover_loss_by_driver_post(
     )
 
     link = DataMartResourceLink(
-        link=f"{API_URL}/v0/land/tree-cover-loss-by-driver/{resource_id}"
+        link=f"{API_URL}/v0/land/tree_cover_loss_by_driver/{resource_id}"
     )
     return DataMartResourceLinkResponse(data=link)
 

--- a/app/tasks/datamart/land.py
+++ b/app/tasks/datamart/land.py
@@ -36,7 +36,7 @@ async def compute_tree_cover_loss_by_driver(
 
         results = await _query_dataset_json(
             "umd_tree_cover_loss",
-            DEFAULT_LAND_DATASET_VERSIONS["umd_tree_cover_loss"],
+            dataset_version["umd_tree_cover_loss"],
             query,
             geostore,
             dataset_version,

--- a/tests_v2/unit/app/routes/datamart/test_land.py
+++ b/tests_v2/unit/app/routes/datamart/test_land.py
@@ -31,13 +31,13 @@ async def test_get_tree_cover_loss_by_drivers_not_found(
         params = {"x-api-key": api_key, "geostore_id": geostore, "canopy_cover": 30}
 
         response = await async_client.get(
-            "/v0/land/tree-cover-loss-by-driver", headers=headers, params=params
+            "/v0/land/tree_cover_loss_by_driver", headers=headers, params=params
         )
 
         assert response.status_code == 404
 
         resource_id = _get_resource_id(
-            "tree-cover-loss-by-driver", geostore, 30, DEFAULT_LAND_DATASET_VERSIONS
+            "tree_cover_loss_by_driver", geostore, 30, DEFAULT_LAND_DATASET_VERSIONS
         )
         mock_get_resources.assert_awaited_with(resource_id)
 
@@ -57,16 +57,16 @@ async def test_get_tree_cover_loss_by_drivers_found(
         headers = {"origin": origin}
         params = {"x-api-key": api_key, "geostore_id": geostore, "canopy_cover": 30}
         resource_id = _get_resource_id(
-            "tree-cover-loss-by-driver", geostore, 30, DEFAULT_LAND_DATASET_VERSIONS
+            "tree_cover_loss_by_driver", geostore, 30, DEFAULT_LAND_DATASET_VERSIONS
         )
 
         response = await async_client.get(
-            "/v0/land/tree-cover-loss-by-driver", headers=headers, params=params
+            "/v0/land/tree_cover_loss_by_driver", headers=headers, params=params
         )
 
         assert response.status_code == 200
         assert (
-            f"/v0/land/tree-cover-loss-by-driver/{resource_id}"
+            f"/v0/land/tree_cover_loss_by_driver/{resource_id}"
             in response.json()["data"]["link"]
         )
         mock_get_resources.assert_awaited_with(resource_id)
@@ -92,7 +92,7 @@ async def test_get_tree_cover_loss_by_drivers_with_overrides(
         headers = {"origin": origin}
         params = {"x-api-key": api_key, "geostore_id": geostore, "canopy_cover": 30}
         resource_id = _get_resource_id(
-            "tree-cover-loss-by-driver",
+            "tree_cover_loss_by_driver",
             geostore,
             30,
             {
@@ -103,14 +103,14 @@ async def test_get_tree_cover_loss_by_drivers_with_overrides(
         )
 
         response = await async_client.get(
-            "/v0/land/tree-cover-loss-by-driver?x-api-key={api_key}&geostore_id={geostore_id}&canopy_cover=30&dataset=umd_tree_cover_loss&version=v1.8&dataset=umd_tree_cover_density_2000&version=v1.6",
+            f"/v0/land/tree_cover_loss_by_driver?geostore_id={geostore}&canopy_cover=30&dataset=umd_tree_cover_loss&version=v1.8&dataset=umd_tree_cover_density_2000&version=v1.6",
             headers=headers,
             params=params,
         )
 
         assert response.status_code == 200
         mock_get_resource_id.assert_called_with(
-            "tree-cover-loss-by-driver",
+            "tree_cover_loss_by_driver",
             uuid.UUID(geostore),
             30,
             {
@@ -120,7 +120,7 @@ async def test_get_tree_cover_loss_by_drivers_with_overrides(
             },
         )
         assert (
-            f"/v0/land/tree-cover-loss-by-driver/{resource_id}"
+            f"/v0/land/tree_cover_loss_by_driver/{resource_id}"
             in response.json()["data"]["link"]
         )
         mock_get_resources.assert_awaited_with(resource_id)
@@ -136,7 +136,11 @@ async def test_post_tree_cover_loss_by_drivers(
     origin = payload["domains"][0]
 
     headers = {"origin": origin, "x-api-key": api_key}
-    payload = {"geostore_id": geostore, "canopy_cover": 30}
+    payload = {
+        "geostore_id": geostore,
+        "canopy_cover": 30,
+        "dataset_version": {"umd_tree_cover_loss": "v1.8"},
+    }
     with (
         patch(
             "app.routes.datamart.land._save_pending_resource"
@@ -146,13 +150,14 @@ async def test_post_tree_cover_loss_by_drivers(
         ) as mock_compute_result,
     ):
         response = await async_client.post(
-            "/v0/land/tree-cover-loss-by-driver", headers=headers, json=payload
+            "/v0/land/tree_cover_loss_by_driver", headers=headers, json=payload
         )
+
         assert response.status_code == 202
 
         body = response.json()
         assert body["status"] == "success"
-        assert "/v0/land/tree-cover-loss-by-driver/" in body["data"]["link"]
+        assert "/v0/land/tree_cover_loss_by_driver/" in body["data"]["link"]
 
         resource_id = body["data"]["link"].split("/")[-1]
         try:
@@ -163,7 +168,10 @@ async def test_post_tree_cover_loss_by_drivers(
 
         mock_pending_resource.assert_awaited_with(resource_id)
         mock_compute_result.assert_awaited_with(
-            resource_id, uuid.UUID(geostore), 30, DEFAULT_LAND_DATASET_VERSIONS
+            resource_id,
+            uuid.UUID(geostore),
+            30,
+            DEFAULT_LAND_DATASET_VERSIONS | {"umd_tree_cover_loss": "v1.8"},
         )
 
 
@@ -182,10 +190,10 @@ async def test_get_tree_cover_loss_by_drivers_after_create_with_retry(
         "app.routes.datamart.land._get_resource", return_value={"status": "pending"}
     ):
         resource_id = _get_resource_id(
-            "tree-cover-loss-by-driver", geostore, 30, DEFAULT_LAND_DATASET_VERSIONS
+            "tree_cover_loss_by_driver", geostore, 30, DEFAULT_LAND_DATASET_VERSIONS
         )
         response = await async_client.get(
-            f"/v0/land/tree-cover-loss-by-driver/{resource_id}", headers=headers
+            f"/v0/land/tree_cover_loss_by_driver/{resource_id}", headers=headers
         )
 
         assert response.status_code == 200
@@ -207,10 +215,10 @@ async def test_get_tree_cover_loss_by_drivers_after_create_saved(
 
     with patch("app.routes.datamart.land._get_resource", return_value=MOCK_RESOURCE):
         resource_id = _get_resource_id(
-            "tree-cover-loss-by-driver", geostore, 30, DEFAULT_LAND_DATASET_VERSIONS
+            "tree_cover_loss_by_driver", geostore, 30, DEFAULT_LAND_DATASET_VERSIONS
         )
         response = await async_client.get(
-            f"/v0/land/tree-cover-loss-by-driver/{resource_id}", headers=headers
+            f"/v0/land/tree_cover_loss_by_driver/{resource_id}", headers=headers
         )
 
         assert response.status_code == 200
@@ -229,20 +237,23 @@ async def test_compute_tree_cover_loss_by_driver(geostore):
         patch("app.tasks.datamart.land._write_resource") as mock_write_result,
     ):
         resource_id = _get_resource_id(
-            "tree-cover-loss-by-driver", geostore, 30, DEFAULT_LAND_DATASET_VERSIONS
+            "tree_cover_loss_by_driver", geostore, 30, DEFAULT_LAND_DATASET_VERSIONS
         )
         geostore_common = await get_geostore(geostore, GeostoreOrigin.rw)
 
         await compute_tree_cover_loss_by_driver(
-            resource_id, geostore, 30, DEFAULT_LAND_DATASET_VERSIONS
+            resource_id,
+            geostore,
+            30,
+            DEFAULT_LAND_DATASET_VERSIONS | {"umd_tree_cover_loss": "v1.8"},
         )
 
         mock_query_dataset_json.assert_awaited_once_with(
             "umd_tree_cover_loss",
-            "v1.11",
+            "v1.8",
             "SELECT SUM(area__ha) FROM data WHERE umd_tree_cover_density_2000__threshold >= 30 GROUP BY tsc_tree_cover_loss_drivers__driver",
             geostore_common,
-            DEFAULT_LAND_DATASET_VERSIONS,
+            DEFAULT_LAND_DATASET_VERSIONS | {"umd_tree_cover_loss": "v1.8"},
         )
 
         MOCK_RESOURCE["metadata"]["geostore_id"] = geostore
@@ -261,7 +272,7 @@ async def test_compute_tree_cover_loss_by_driver_error(geostore):
         patch("app.tasks.datamart.land._write_error") as mock_write_error,
     ):
         resource_id = _get_resource_id(
-            "tree-cover-loss-by-driver", geostore, 30, DEFAULT_LAND_DATASET_VERSIONS
+            "tree_cover_loss_by_driver", geostore, 30, DEFAULT_LAND_DATASET_VERSIONS
         )
         geostore_common = await get_geostore(geostore, GeostoreOrigin.rw)
 
@@ -327,7 +338,7 @@ MOCK_RESOURCE = {
         "geostore_id": "",
         "canopy_cover": 30,
         "sources": [
-            {"dataset": "umd_tree_cover_loss", "version": "v1.11"},
+            {"dataset": "umd_tree_cover_loss", "version": "v1.8"},
             {"dataset": "tsc_tree_cover_loss_drivers", "version": "v2023"},
             {"dataset": "umd_tree_cover_density_2000", "version": "v1.8"},
         ],

--- a/tests_v2/unit/app/routes/datasets/test_query.py
+++ b/tests_v2/unit/app/routes/datasets/test_query.py
@@ -1,17 +1,32 @@
 import re
 from typing import Tuple
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 from urllib.parse import parse_qsl, urlparse
 from uuid import UUID
 
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
-from httpx import AsyncClient
+from fastapi import HTTPException
+from httpx import AsyncClient, Response
 
+from app.crud.assets import get_default_asset
+from app.models.enum.creation_options import Delimiters
+from app.models.enum.geostore import GeostoreOrigin
 from app.models.enum.pixetl import Grid
-from app.models.pydantic.raster_analysis import DerivedLayer, SourceLayer
+from app.models.pydantic.raster_analysis import (
+    DataEnvironment,
+    DerivedLayer,
+    SourceLayer,
+)
 from app.routes.datasets import queries
-from app.routes.datasets.queries import _get_data_environment, _get_data_environment_sql
+from app.routes.datasets.queries import (
+    _get_data_environment,
+    _get_data_environment_sql,
+    _query_dataset_json,
+    _query_raster,
+    _query_raster_lambda,
+)
+from app.utils.geostore import get_geostore
 from tests_v2.fixtures.creation_options.versions import RASTER_CREATION_OPTIONS
 from tests_v2.utils import (
     custom_raster_version,
@@ -821,6 +836,120 @@ async def test_query_batch_uri(
     assert data["status"] == "pending"
 
     assert response.json()["status"] == "success"
+
+
+@pytest.mark.asyncio
+async def test_query_dataset_json_with_overrides(
+    generic_raster_version,
+    geostore,
+):
+    dataset_name, version_name, _ = generic_raster_version
+    geostore_common = await get_geostore(geostore, GeostoreOrigin.rw)
+    sql = "SELECT sum(area__ha) FROM data"
+
+    with patch(
+        "app.routes.datasets.queries._query_raster", return_value={"data": []}
+    ) as mock_query_raster:
+        result = await _query_dataset_json(
+            dataset_name, version_name, sql, geostore_common, {dataset_name: "v2"}
+        )
+
+        mock_query_raster.assert_awaited_once()
+        args = mock_query_raster.await_args
+        assert args[1]["version_overrides"] == {dataset_name: "v2"}
+        assert result == []
+
+
+@pytest.mark.asyncio
+async def test_query_raster_with_overrides(
+    generic_raster_version,
+    geostore,
+):
+    dataset_name, version_name, _ = generic_raster_version
+    asset = await get_default_asset(dataset_name, version_name)
+    geostore_common = await get_geostore(geostore, GeostoreOrigin.rw)
+    sql = "SELECT sum(area__ha) FROM data"
+
+    with patch(
+        "app.routes.datasets.queries._query_raster_lambda", return_value={"data": []}
+    ) as mock_raster_query_lambda:
+        result = await _query_raster(
+            dataset_name,
+            asset,
+            sql,
+            geostore_common,
+            version_overrides={dataset_name: "v2"},
+        )
+
+        mock_raster_query_lambda.assert_awaited_once()
+        args = mock_raster_query_lambda.await_args
+        assert args[0][5] == {dataset_name: "v2"}
+        assert result == {"data": []}
+
+
+@pytest.mark.asyncio
+async def test_query_raster_lambda_with_overrides(
+    generic_raster_version,
+    geostore,
+):
+    dataset_name, _, _ = generic_raster_version
+    geostore_common = await get_geostore(geostore, GeostoreOrigin.rw)
+    sql = "SELECT sum(area__ha) FROM data"
+
+    with (
+        patch(
+            "app.routes.datasets.queries._get_data_environment",
+            return_value=DataEnvironment(layers=[]),
+        ) as mock_get_data_environment,
+        patch(
+            "app.routes.datasets.queries.invoke_lambda",
+            return_value=Response(status_code=500),
+        ),
+    ):
+        try:
+            await _query_raster_lambda(
+                geostore_common.geojson,
+                sql,
+                Grid.ten_by_forty_thousand,
+                Delimiters.comma,
+                version_overrides={dataset_name: "v2"},
+            )
+        except HTTPException:
+            mock_get_data_environment.assert_awaited_once_with(
+                Grid.ten_by_forty_thousand, {dataset_name: "v2"}
+            )
+
+
+@pytest.mark.asyncio
+async def test_get_data_environment_sql():
+    sql = _get_data_environment_sql(
+        {"umd_tree_cover_loss": "v1.9", "umd_tree_cover_density_2000": "v1.6"}
+    )
+    assert sql.strip() == DATA_ENV_SQL.strip()
+
+
+DATA_ENV_SQL = """
+    SELECT
+      assets.asset_id,
+      assets.dataset,
+      assets.version,
+      creation_options,
+      asset_uri,
+      rb.values_table
+    FROM
+      assets
+      LEFT JOIN asset_metadata am
+        ON am.asset_id = assets.asset_id
+      JOIN versions
+        ON versions.dataset = assets.dataset
+        AND versions.version = assets.version
+      LEFT JOIN raster_band_metadata rb
+        ON rb.asset_metadata_id = am.id
+      WHERE assets.asset_type = 'Raster tile set'
+      AND assets.creation_options->>'pixel_meaning' NOT LIKE '%tcd%'
+      AND assets.creation_options->>'grid' = :grid
+     AND ((assets.dataset NOT IN ('umd_tree_cover_loss', 'umd_tree_cover_density_2000') AND versions.is_latest = true) OR (assets.dataset = 'umd_tree_cover_loss' AND assets.version = 'v1.9') OR (assets.dataset = 'umd_tree_cover_density_2000' AND assets.version = 'v1.6'))
+"""
 
 
 FEATURE_COLLECTION = {


### PR DESCRIPTION
- Snake case for everything, including API path, to be consistent. 
-Missed that the call in the compute task to query_dataset_json always used the default version for 
- umd_tree_cover_loss as the default asset, but should use the version override if it exists. While trying to find this, ending up adding other unit tests for queries module to make sure everything is covered. 