### PR TITLE
GTC-3172: Support GADM areas in drivers endpoints

### DIFF
--- a/app/crud/geostore.py
+++ b/app/crud/geostore.py
@@ -9,7 +9,6 @@ from sqlalchemy.sql import Select, label
 from sqlalchemy.sql.elements import Label, TextClause
 
 from app.application import db
-from app.crud.tasks import create_or_update_task
 from app.errors import (
     BadAdminSourceException,
     BadAdminVersionException,
@@ -213,7 +212,7 @@ async def get_gadm_geostore_id(
         src_table,
         subregion_id,
     )
-    return await row.gfw_geostore_id
+    return row.gfw_geostore_id
 
 
 async def build_gadm_geostore(

--- a/app/crud/geostore.py
+++ b/app/crud/geostore.py
@@ -192,17 +192,27 @@ async def get_first_row(sql: Select):
 
 
 async def get_gadm_geostore_id(
-        admin_provider: str,
-        admin_version: str,
-        adm_level: int,
-        country_id: str,
-        region_id: str | None = None,
-        subregion_id: str | None = None,
+    admin_provider: str,
+    admin_version: str,
+    adm_level: int,
+    country_id: str,
+    region_id: str | None = None,
+    subregion_id: str | None = None,
 ) -> str:
     src_table = await get_versioned_dataset(admin_provider, admin_version)
-    columns_etc: List[Column | Label] = [db.column("gfw_geostore_id"),]
-    row = await _find_first_geostore(adm_level, admin_provider, admin_version, columns_etc, country_id, region_id,
-                               src_table, subregion_id)
+    columns_etc: List[Column | Label] = [
+        db.column("gfw_geostore_id"),
+    ]
+    row = await _find_first_geostore(
+        adm_level,
+        admin_provider,
+        admin_version,
+        columns_etc,
+        country_id,
+        region_id,
+        src_table,
+        subregion_id,
+    )
     return await row.gfw_geostore_id
 
 
@@ -240,8 +250,16 @@ async def build_gadm_geostore(
             )
         )
 
-    row = await _find_first_geostore(adm_level, admin_provider, admin_version, columns_etc, country_id, region_id,
-                                     src_table, subregion_id)
+    row = await _find_first_geostore(
+        adm_level,
+        admin_provider,
+        admin_version,
+        columns_etc,
+        country_id,
+        region_id,
+        src_table,
+        subregion_id,
+    )
 
     if row.geojson is None:
         raise GeometryIsNullError(
@@ -261,10 +279,26 @@ async def build_gadm_geostore(
     )
 
 
-async def _find_first_geostore(adm_level, admin_provider, admin_version, columns_etc, country_id, region_id, src_table,
-                               subregion_id):
+async def _find_first_geostore(
+    adm_level,
+    admin_provider,
+    admin_version,
+    columns_etc,
+    country_id,
+    region_id,
+    src_table,
+    subregion_id,
+):
     sql: Select = db.select(columns_etc).select_from(src_table)
-    sql = await add_where_clauses(adm_level, admin_provider, admin_version, country_id, region_id, sql, subregion_id)
+    sql = await add_where_clauses(
+        adm_level,
+        admin_provider,
+        admin_version,
+        country_id,
+        region_id,
+        sql,
+        subregion_id,
+    )
     row = await get_first_row(sql)
     if row is None:
         raise RecordNotFoundError(
@@ -273,7 +307,9 @@ async def _find_first_geostore(adm_level, admin_provider, admin_version, columns
     return row
 
 
-async def add_where_clauses(adm_level, admin_provider, admin_version, country_id, region_id, sql, subregion_id):
+async def add_where_clauses(
+    adm_level, admin_provider, admin_version, country_id, region_id, sql, subregion_id
+):
     where_clauses: List[TextClause] = [
         db.text("adm_level=:adm_level").bindparams(adm_level=str(adm_level))
     ]
@@ -335,7 +371,7 @@ async def get_gadm_geostore(
         admin_version=admin_version,
         adm_level=adm_level,
         simplify=simplify,
-    country_id=country_id,
+        country_id=country_id,
         region_id=region_id,
         subregion_id=subregion_id,
     )

--- a/app/crud/geostore.py
+++ b/app/crud/geostore.py
@@ -191,6 +191,27 @@ async def get_first_row(sql: Select):
     return row
 
 
+async def get_gadm_geostore_id(
+        admin_provider: str,
+        admin_version: str,
+        adm_level: int,
+        country_id: str,
+        region_id: str | None = None,
+        subregion_id: str | None = None,
+) -> str:
+    src_table = await get_versioned_dataset(admin_provider, admin_version)
+    columns_etc: List[Column | Label] = [db.column("gfw_geostore_id"),]
+    sql: Select = db.select(columns_etc).select_from(src_table)
+    sql = await add_where_clauses(adm_level, admin_provider, admin_version, country_id, region_id, sql, subregion_id)
+    row = await get_first_row(sql)
+    if row is None:
+        raise RecordNotFoundError(
+            f"Admin boundary not found in {admin_provider} version {admin_version}"
+        )
+
+    return await row.gfw_geostore_id
+
+
 async def build_gadm_geostore(
     admin_provider: str,
     admin_version: str,

--- a/app/models/pydantic/datamart.py
+++ b/app/models/pydantic/datamart.py
@@ -8,7 +8,7 @@ from pydantic import Field
 from app.models.pydantic.responses import Response
 
 from .base import StrictBaseModel
-from ...crud.geostore import build_gadm_geostore
+from ...crud.geostore import get_gadm_geostore_id
 
 
 class AreaOfInterest(StrictBaseModel, ABC):
@@ -35,16 +35,15 @@ class AdminAreaOfInterest(AreaOfInterest):
 
     async def get_geostore_id(self) -> UUID:
         admin_level = sum(1 for field in (self.country, self.region, self.subregion) if field is not None) - 1
-        geostore = await build_gadm_geostore(
+        geostore_id = await get_gadm_geostore_id(
             admin_provider=self.provider,
             admin_version=self.version,
             adm_level=admin_level,
-            simplify=None,
             country_id=self.country,
             region_id=self.region,
             subregion_id=self.subregion,
         )
-        return UUID(geostore.id)
+        return UUID(geostore_id)
 
 
 class AnalysisStatus(str, Enum):

--- a/app/models/pydantic/datamart.py
+++ b/app/models/pydantic/datamart.py
@@ -1,12 +1,26 @@
 from enum import Enum
-from typing import Dict, Optional
+from typing import Dict, Optional, Union
 from uuid import UUID
+from abc import ABC, abstractmethod
 
 from pydantic import Field
 
 from app.models.pydantic.responses import Response
 
 from .base import StrictBaseModel
+
+class AreaOfInterest(StrictBaseModel, ABC):
+    @abstractmethod
+    def get_geostore_id(self) -> UUID:
+        """Return the unique identifier for the area of interest."""
+        pass
+
+
+class GeostoreAreaOfInterest(AreaOfInterest):
+    geostore_id:UUID = Field(..., title="Geostore ID")
+
+    def get_geostore_id(self) -> UUID:
+        return self.geostore_id
 
 
 class AnalysisStatus(str, Enum):
@@ -43,7 +57,7 @@ class DataMartResourceLinkResponse(Response):
 
 
 class TreeCoverLossByDriverIn(StrictBaseModel):
-    geostore_id: UUID
+    aoi: Union[GeostoreAreaOfInterest]
     canopy_cover: int = 30
     dataset_version: Dict[str, str] = {}
 
@@ -76,3 +90,6 @@ class TreeCoverLossByDriverUpdate(StrictBaseModel):
 
 class TreeCoverLossByDriverResponse(Response):
     data: TreeCoverLossByDriver
+
+
+

--- a/app/models/pydantic/datamart.py
+++ b/app/models/pydantic/datamart.py
@@ -92,7 +92,7 @@ class DataMartResource(StrictBaseModel):
     message: Optional[str] = None
     requested_by: Optional[UUID] = None
     endpoint: str
-    metadata: DataMartMetadata = None
+    metadata: Optional[DataMartMetadata] = None
 
 
 class DataMartResourceLink(StrictBaseModel):

--- a/app/models/pydantic/datamart.py
+++ b/app/models/pydantic/datamart.py
@@ -1,14 +1,14 @@
+from abc import ABC, abstractmethod
 from enum import Enum
 from typing import Dict, Literal, Optional, Union
 from uuid import UUID
-from abc import ABC, abstractmethod
 
 from pydantic import Field, root_validator, validator
 
 from app.models.pydantic.responses import Response
 
-from .base import StrictBaseModel
 from ...crud.geostore import get_gadm_geostore_id
+from .base import StrictBaseModel
 
 
 class AreaOfInterest(StrictBaseModel, ABC):
@@ -19,24 +19,30 @@ class AreaOfInterest(StrictBaseModel, ABC):
 
 
 class GeostoreAreaOfInterest(AreaOfInterest):
-    type: Literal['geostore'] = 'geostore'
-    geostore_id:UUID = Field(..., title="Geostore ID")
+    type: Literal["geostore"] = "geostore"
+    geostore_id: UUID = Field(..., title="Geostore ID")
 
     async def get_geostore_id(self) -> UUID:
         return self.geostore_id
 
 
 class AdminAreaOfInterest(AreaOfInterest):
-    type: Literal['admin'] = 'admin'
+    type: Literal["admin"] = "admin"
     country: str = Field(..., title="ISO Country Code")
     region: Optional[str] = Field(None, title="Region")
     subregion: Optional[str] = Field(None, title="Subregion")
-    provider: str = Field('gadm', title="Administrative Boundary Provider")
-    version: str = Field('4.1', title="Administrative Boundary Version")
-
+    provider: str = Field("gadm", title="Administrative Boundary Provider")
+    version: str = Field("4.1", title="Administrative Boundary Version")
 
     async def get_geostore_id(self) -> UUID:
-        admin_level = sum(1 for field in (self.country, self.region, self.subregion) if field is not None) - 1
+        admin_level = (
+            sum(
+                1
+                for field in (self.country, self.region, self.subregion)
+                if field is not None
+            )
+            - 1
+        )
         geostore_id = await get_gadm_geostore_id(
             admin_provider=self.provider,
             admin_version=self.version,
@@ -55,14 +61,13 @@ class AdminAreaOfInterest(AreaOfInterest):
             raise ValueError("region must be specified if subregion is provided")
         return values
 
-    @validator('provider', pre=True, always=True)
+    @validator("provider", pre=True, always=True)
     def set_provider_default(cls, v):
-        return v or 'gadm'
+        return v or "gadm"
 
-    @validator('version', pre=True, always=True)
+    @validator("version", pre=True, always=True)
     def set_version_default(cls, v):
-        return v or '4.1'
-
+        return v or "4.1"
 
 
 class AnalysisStatus(str, Enum):
@@ -99,7 +104,9 @@ class DataMartResourceLinkResponse(Response):
 
 
 class TreeCoverLossByDriverIn(StrictBaseModel):
-    aoi: Union[GeostoreAreaOfInterest, AdminAreaOfInterest] = Field(..., discriminator='type')
+    aoi: Union[GeostoreAreaOfInterest, AdminAreaOfInterest] = Field(
+        ..., discriminator="type"
+    )
     canopy_cover: int = 30
     dataset_version: Dict[str, str] = {}
 
@@ -132,6 +139,3 @@ class TreeCoverLossByDriverUpdate(StrictBaseModel):
 
 class TreeCoverLossByDriverResponse(Response):
     data: TreeCoverLossByDriver
-
-
-

--- a/app/routes/datamart/__init__.py
+++ b/app/routes/datamart/__init__.py
@@ -1,0 +1,56 @@
+OPENAPI_EXTRA = {
+    "parameters": [
+        {
+            "name": "aoi",
+            "in": "query",
+            "required": True,
+            "style": "deepObject",
+            "explode": True,
+            "examples": {
+                "Geostore Area Of Interest": {
+                    "summary": "Geostore Area Of Interest",
+                    "description": "Custom area",
+                    "value": {
+                        "type": "geostore",
+                        "geostore_id": "637d378f-93a9-4364-bfa8-95b6afd28c3a",
+                    }
+                },
+                "Admin Area Of Interest": {
+                    "summary": "Admin Area Of Interest",
+                    "description": "Administrative Boundary",
+                    "value": {
+                        "type": "admin",
+                        "country": "BRA",
+                        "region": "12",
+                        "subregion": "2",
+                    }
+                }
+            },
+            "description": "The Area of Interest",
+            "schema": {
+                "oneOf": [
+                    {"$ref": "#/components/schemas/GeostoreAreaOfInterest"},
+                    {"$ref": "#/components/schemas/AdminAreaOfInterest"},
+                ]
+            }
+        },
+        {
+            "name": "dataset_version",
+            "in": "query",
+            "required": False,
+            "style": "deepObject",
+            "explode": True,
+            "schema": {
+                "type": "object",
+                "additionalProperties": {"type": "string"},
+            },
+            "example": {
+                "umd_tree_cover_loss": "v1.11",
+                "tsc_tree_cover_loss_drivers": "v2023",
+            },
+            "description": (
+                "Pass dataset version overrides as bracketed query parameters.",
+            )
+        }
+    ]
+}

--- a/app/routes/datamart/__init__.py
+++ b/app/routes/datamart/__init__.py
@@ -13,7 +13,7 @@ OPENAPI_EXTRA = {
                     "value": {
                         "type": "geostore",
                         "geostore_id": "637d378f-93a9-4364-bfa8-95b6afd28c3a",
-                    }
+                    },
                 },
                 "Admin Area Of Interest": {
                     "summary": "Admin Area Of Interest",
@@ -23,8 +23,8 @@ OPENAPI_EXTRA = {
                         "country": "BRA",
                         "region": "12",
                         "subregion": "2",
-                    }
-                }
+                    },
+                },
             },
             "description": "The Area of Interest",
             "schema": {
@@ -32,7 +32,7 @@ OPENAPI_EXTRA = {
                     {"$ref": "#/components/schemas/GeostoreAreaOfInterest"},
                     {"$ref": "#/components/schemas/AdminAreaOfInterest"},
                 ]
-            }
+            },
         },
         {
             "name": "dataset_version",
@@ -50,7 +50,7 @@ OPENAPI_EXTRA = {
             },
             "description": (
                 "Pass dataset version overrides as bracketed query parameters.",
-            )
-        }
+            ),
+        },
     ]
 }

--- a/app/routes/datamart/land.py
+++ b/app/routes/datamart/land.py
@@ -23,16 +23,16 @@ from app.crud import datamart as datamart_crud
 from app.errors import RecordNotFoundError
 from app.models.enum.geostore import GeostoreOrigin
 from app.models.pydantic.datamart import (
+    AdminAreaOfInterest,
     AnalysisStatus,
+    AreaOfInterest,
     DataMartResource,
     DataMartResourceLink,
     DataMartResourceLinkResponse,
+    GeostoreAreaOfInterest,
     TreeCoverLossByDriver,
     TreeCoverLossByDriverIn,
     TreeCoverLossByDriverResponse,
-    AreaOfInterest,
-    GeostoreAreaOfInterest,
-    AdminAreaOfInterest,
 )
 from app.settings.globals import API_URL
 from app.tasks.datamart.land import (
@@ -40,11 +40,12 @@ from app.tasks.datamart.land import (
     compute_tree_cover_loss_by_driver,
 )
 from app.utils.geostore import get_geostore
-from . import OPENAPI_EXTRA
 
 from ...authentication.api_keys import get_api_key
+from . import OPENAPI_EXTRA
 
 router = APIRouter()
+
 
 def _parse_dataset_versions(request: Request) -> Dict[str, str]:
     dataset_versions = {}
@@ -69,23 +70,27 @@ def _parse_dataset_versions(request: Request) -> Dict[str, str]:
 
 def _parse_area_of_interest(request: Request) -> AreaOfInterest:
     params = request.query_params
-    aoi_type = params.get('aoi[type]')
+    aoi_type = params.get("aoi[type]")
     try:
-        if aoi_type == 'geostore':
-            return GeostoreAreaOfInterest(geostore_id=params.get('aoi[geostore_id]', None))
+        if aoi_type == "geostore":
+            return GeostoreAreaOfInterest(
+                geostore_id=params.get("aoi[geostore_id]", None)
+            )
 
             # Otherwise, check if the request contains admin area information
-        if aoi_type == 'admin':
+        if aoi_type == "admin":
             return AdminAreaOfInterest(
-                country=params.get('aoi[country]', None),
-                region=params.get('aoi[region]', None),
-                subregion=params.get('aoi[subregion]', None),
-                provider=params.get('aoi[provider]', None),
-                version=params.get('aoi[version]', None),
+                country=params.get("aoi[country]", None),
+                region=params.get("aoi[region]", None),
+                subregion=params.get("aoi[subregion]", None),
+                provider=params.get("aoi[provider]", None),
+                version=params.get("aoi[version]", None),
             )
 
         # If neither type is provided, raise an error
-        raise HTTPException(status_code=422, detail="Invalid Area of Interest parameters")
+        raise HTTPException(
+            status_code=422, detail="Invalid Area of Interest parameters"
+        )
     except ValidationError as e:
         raise HTTPException(status_code=422, detail=e.errors())
 
@@ -96,7 +101,7 @@ def _parse_area_of_interest(request: Request) -> AreaOfInterest:
     response_model=DataMartResourceLinkResponse,
     tags=["Land"],
     status_code=200,
-    openapi_extra= OPENAPI_EXTRA,
+    openapi_extra=OPENAPI_EXTRA,
 )
 async def tree_cover_loss_by_driver_search(
     *,

--- a/app/routes/datamart/land.py
+++ b/app/routes/datamart/land.py
@@ -40,6 +40,7 @@ from app.tasks.datamart.land import (
     compute_tree_cover_loss_by_driver,
 )
 from app.utils.geostore import get_geostore
+from . import OPENAPI_EXTRA
 
 from ...authentication.api_keys import get_api_key
 
@@ -95,45 +96,7 @@ def _parse_area_of_interest(request: Request) -> AreaOfInterest:
     response_model=DataMartResourceLinkResponse,
     tags=["Land"],
     status_code=200,
-    openapi_extra={
-        "parameters": [
-            {
-                "name": "aoi",
-                "in": "query",
-                "required": True,
-                "style": "deepObject",
-                "explode": True,
-                "example": {
-                    "geostore_id": "637d378f-93a9-4364-bfa8-95b6afd28c3a",
-                },
-                "description": "The Area of Interest",
-                "schema": {
-                    "oneOf": [
-                        {"$ref": "#/components/schemas/GeostoreAreaOfInterest"},
-                        {"$ref": "#/components/schemas/AdminAreaOfInterest"},
-                    ]
-                }
-            },
-            {
-                "name": "dataset_version",
-                "in": "query",
-                "required": False,
-                "style": "deepObject",
-                "explode": True,
-                "schema": {
-                    "type": "object",
-                    "additionalProperties": {"type": "string"},
-                },
-                "example": {
-                    "umd_tree_cover_loss": "v1.11",
-                    "tsc_tree_cover_loss_drivers": "v2023",
-                },
-                "description": (
-                        "Pass dataset version overrides as bracketed query parameters.",
-                )
-            }
-        ]
-    },
+    openapi_extra= OPENAPI_EXTRA,
 )
 async def tree_cover_loss_by_driver_search(
     *,

--- a/app/routes/datamart/land.py
+++ b/app/routes/datamart/land.py
@@ -246,9 +246,6 @@ async def _get_resource(resource_id):
         )
 
 
-
-
-
 async def _save_pending_resource(resource_id, endpoint, api_key):
     pending_resource = DataMartResource(
         id=resource_id,

--- a/tests_v2/unit/app/crud/test_geostore.py
+++ b/tests_v2/unit/app/crud/test_geostore.py
@@ -8,9 +8,7 @@ from app.errors import RecordNotFoundError
 
 
 @pytest.mark.asyncio
-async def test_get_gadm_geostore_generates_correct_sql_for_country_lookup(
-    async_client: AsyncClient,
-):
+async def test_get_gadm_geostore_generates_correct_sql_for_country_lookup():
     provider = "gadm"
     version = "4.1"
     adm_level = 0
@@ -44,9 +42,7 @@ async def test_get_gadm_geostore_generates_correct_sql_for_country_lookup(
 
 
 @pytest.mark.asyncio
-async def test_get_gadm_geostore_generates_correct_sql_for_region_lookup(
-    async_client: AsyncClient,
-):
+async def test_get_gadm_geostore_generates_correct_sql_for_region_lookup():
     provider = "gadm"
     version = "4.1"
     adm_level = 1
@@ -81,9 +77,7 @@ async def test_get_gadm_geostore_generates_correct_sql_for_region_lookup(
 
 
 @pytest.mark.asyncio
-async def test_get_gadm_geostore_generates_correct_sql_for_subregion_lookup(
-    async_client: AsyncClient,
-):
+async def test_get_gadm_geostore_generates_correct_sql_for_subregion_lookup():
     provider = "gadm"
     version = "4.1"
     adm_level = 2
@@ -120,9 +114,7 @@ async def test_get_gadm_geostore_generates_correct_sql_for_subregion_lookup(
 
 class TestGadmGeostoreIDLookup:
     @pytest.mark.asyncio
-    async def test_get_gadm_geostore_id_generates_correct_sql_for_country_lookup(
-        async_client: AsyncClient,
-    ):
+    async def test_get_gadm_geostore_id_generates_correct_sql_for_country_lookup(self):
         provider = "gadm"
         version = "4.1"
         adm_level = 0
@@ -153,9 +145,7 @@ class TestGadmGeostoreIDLookup:
         assert actual_sql == expected_sql
 
     @pytest.mark.asyncio
-    async def test_get_gadm_geostore_id_generates_correct_sql_for_region_lookup(
-        async_client: AsyncClient,
-    ):
+    async def test_get_gadm_geostore_id_generates_correct_sql_for_region_lookup(self):
         provider = "gadm"
         version = "4.1"
         adm_level = 1
@@ -187,9 +177,7 @@ class TestGadmGeostoreIDLookup:
         assert actual_sql == expected_sql
 
     @pytest.mark.asyncio
-    async def test_get_gadm_geostore_id_generates_correct_sql_for_subregion_lookup(
-        async_client: AsyncClient,
-    ):
+    async def test_get_gadm_geostore_id_generates_correct_sql_for_subregion_lookup(self):
         provider = "gadm"
         version = "4.1"
         adm_level = 2

--- a/tests_v2/unit/app/crud/test_geostore.py
+++ b/tests_v2/unit/app/crud/test_geostore.py
@@ -9,7 +9,7 @@ from app.errors import RecordNotFoundError
 
 @pytest.mark.asyncio
 async def test_get_gadm_geostore_generates_correct_sql_for_country_lookup(
-        async_client: AsyncClient
+    async_client: AsyncClient,
 ):
     provider = "gadm"
     version = "4.1"
@@ -45,7 +45,7 @@ async def test_get_gadm_geostore_generates_correct_sql_for_country_lookup(
 
 @pytest.mark.asyncio
 async def test_get_gadm_geostore_generates_correct_sql_for_region_lookup(
-        async_client: AsyncClient
+    async_client: AsyncClient,
 ):
     provider = "gadm"
     version = "4.1"
@@ -82,7 +82,7 @@ async def test_get_gadm_geostore_generates_correct_sql_for_region_lookup(
 
 @pytest.mark.asyncio
 async def test_get_gadm_geostore_generates_correct_sql_for_subregion_lookup(
-        async_client: AsyncClient
+    async_client: AsyncClient,
 ):
     provider = "gadm"
     version = "4.1"
@@ -121,7 +121,7 @@ async def test_get_gadm_geostore_generates_correct_sql_for_subregion_lookup(
 class TestGadmGeostoreIDLookup:
     @pytest.mark.asyncio
     async def test_get_gadm_geostore_id_generates_correct_sql_for_country_lookup(
-            async_client: AsyncClient
+        async_client: AsyncClient,
     ):
         provider = "gadm"
         version = "4.1"
@@ -152,10 +152,9 @@ class TestGadmGeostoreIDLookup:
         assert mock_get_first_row.called is True
         assert actual_sql == expected_sql
 
-
     @pytest.mark.asyncio
     async def test_get_gadm_geostore_id_generates_correct_sql_for_region_lookup(
-            async_client: AsyncClient
+        async_client: AsyncClient,
     ):
         provider = "gadm"
         version = "4.1"
@@ -187,10 +186,9 @@ class TestGadmGeostoreIDLookup:
         assert mock_get_first_row.called is True
         assert actual_sql == expected_sql
 
-
     @pytest.mark.asyncio
     async def test_get_gadm_geostore_id_generates_correct_sql_for_subregion_lookup(
-            async_client: AsyncClient
+        async_client: AsyncClient,
     ):
         provider = "gadm"
         version = "4.1"

--- a/tests_v2/unit/app/crud/test_geostore.py
+++ b/tests_v2/unit/app/crud/test_geostore.py
@@ -3,13 +3,13 @@ from unittest.mock import patch
 import pytest
 from httpx import AsyncClient
 
-from app.crud.geostore import get_gadm_geostore
+from app.crud.geostore import get_gadm_geostore, get_gadm_geostore_id
 from app.errors import RecordNotFoundError
 
 
 @pytest.mark.asyncio
 async def test_get_gadm_geostore_generates_correct_sql_for_country_lookup(
-    async_client: AsyncClient
+        async_client: AsyncClient
 ):
     provider = "gadm"
     version = "4.1"
@@ -45,7 +45,7 @@ async def test_get_gadm_geostore_generates_correct_sql_for_country_lookup(
 
 @pytest.mark.asyncio
 async def test_get_gadm_geostore_generates_correct_sql_for_region_lookup(
-    async_client: AsyncClient
+        async_client: AsyncClient
 ):
     provider = "gadm"
     version = "4.1"
@@ -80,10 +80,9 @@ async def test_get_gadm_geostore_generates_correct_sql_for_region_lookup(
     assert actual_sql == expected_sql
 
 
-
 @pytest.mark.asyncio
 async def test_get_gadm_geostore_generates_correct_sql_for_subregion_lookup(
-    async_client: AsyncClient
+        async_client: AsyncClient
 ):
     provider = "gadm"
     version = "4.1"
@@ -117,3 +116,109 @@ async def test_get_gadm_geostore_generates_correct_sql_for_subregion_lookup(
 
     assert mock_get_first_row.called is True
     assert actual_sql == expected_sql
+
+
+class TestGadmGeostoreIDLookup:
+    @pytest.mark.asyncio
+    async def test_get_gadm_geostore_id_generates_correct_sql_for_country_lookup(
+            async_client: AsyncClient
+    ):
+        provider = "gadm"
+        version = "4.1"
+        adm_level = 0
+        country_id = "MEX"
+
+        with patch("app.crud.geostore.get_first_row") as mock_get_first_row:
+            mock_get_first_row.return_value = None
+            try:
+                _ = await get_gadm_geostore_id(
+                    provider, version, adm_level, country_id, None, None
+                )
+            except RecordNotFoundError:
+                pass
+
+        expected_sql = (
+            "SELECT gfw_geostore_id "
+            '\nFROM gadm_administrative_boundaries."v4.1.64" \n'
+            "WHERE adm_level='0' AND gid_0='MEX'"
+        )
+
+        actual_sql = str(
+            mock_get_first_row.call_args.args[0].compile(
+                compile_kwargs={"literal_binds": True}
+            )
+        )
+
+        assert mock_get_first_row.called is True
+        assert actual_sql == expected_sql
+
+
+    @pytest.mark.asyncio
+    async def test_get_gadm_geostore_id_generates_correct_sql_for_region_lookup(
+            async_client: AsyncClient
+    ):
+        provider = "gadm"
+        version = "4.1"
+        adm_level = 1
+        country = "MEX"
+        region = "5"
+
+        with patch("app.crud.geostore.get_first_row") as mock_get_first_row:
+            mock_get_first_row.return_value = None
+            try:
+                _ = await get_gadm_geostore_id(
+                    provider, version, adm_level, country, region, None
+                )
+            except RecordNotFoundError:
+                pass
+
+        expected_sql = (
+            "SELECT gfw_geostore_id "
+            '\nFROM gadm_administrative_boundaries."v4.1.64" \n'
+            r"WHERE adm_level='1' AND gid_1 LIKE 'MEX.5\__'"
+        )
+
+        actual_sql = str(
+            mock_get_first_row.call_args.args[0].compile(
+                compile_kwargs={"literal_binds": True}
+            )
+        )
+
+        assert mock_get_first_row.called is True
+        assert actual_sql == expected_sql
+
+
+    @pytest.mark.asyncio
+    async def test_get_gadm_geostore_id_generates_correct_sql_for_subregion_lookup(
+            async_client: AsyncClient
+    ):
+        provider = "gadm"
+        version = "4.1"
+        adm_level = 2
+        country = "MEX"
+        region = "5"
+        subregion = "2"
+
+        with patch("app.crud.geostore.get_first_row") as mock_get_first_row:
+            mock_get_first_row.return_value = None
+            try:
+                _ = await get_gadm_geostore_id(
+                    provider, version, adm_level, country, region, subregion
+                )
+            except RecordNotFoundError:
+                pass
+
+        expected_sql = (
+            "SELECT gfw_geostore_id "
+            '\nFROM gadm_administrative_boundaries."v4.1.64" \n'
+            r"WHERE adm_level='2' AND gid_2 LIKE 'MEX.5.2\__'"
+        )
+
+        actual_sql = str(
+            mock_get_first_row.call_args.args[0].compile(
+                compile_kwargs={"literal_binds": True}
+            )
+        )
+
+        assert mock_get_first_row.called is True
+        assert actual_sql == expected_sql

--- a/tests_v2/unit/app/routes/datamart/test_land.py
+++ b/tests_v2/unit/app/routes/datamart/test_land.py
@@ -398,3 +398,36 @@ MOCK_ERROR_RESOURCE = {
         ],
     },
 }
+
+
+class TestAdminAreaOfInterest:
+    @pytest.mark.asyncio
+    async def test_get_tree_cover_loss_by_drivers_found(
+            self,
+            geostore,
+            apikey,
+            async_client: AsyncClient,
+    ):
+        with (
+            patch("app.routes.datamart.land._get_resource", return_value=None) as mock_get_resources,
+            patch("app.models.pydantic.datamart.get_gadm_geostore_id", return_value=geostore)
+        ):
+            api_key, payload = apikey
+            origin = payload["domains"][0]
+
+            headers = {"origin": origin}
+            params = {"x-api-key": api_key, "aoi[type]": "admin", "aoi[country]": "BRA", "canopy_cover": 30}
+            resource_id = _get_resource_id(
+                "tree_cover_loss_by_driver", geostore, 30, DEFAULT_LAND_DATASET_VERSIONS
+            )
+
+            response = await async_client.get(
+                "/v0/land/tree_cover_loss_by_driver", headers=headers, params=params
+            )
+
+            assert response.status_code == 200
+            assert (
+                    f"/v0/land/tree_cover_loss_by_driver/{resource_id}"
+                    in response.json()["data"]["link"]
+            )
+            mock_get_resources.assert_awaited_with(resource_id)

--- a/tests_v2/unit/app/routes/datamart/test_land.py
+++ b/tests_v2/unit/app/routes/datamart/test_land.py
@@ -32,7 +32,7 @@ async def test_get_tree_cover_loss_by_drivers_not_found(
         origin = payload["domains"][0]
 
         headers = {"origin": origin}
-        params = {"x-api-key": api_key, "aoi[geostore_id]": geostore, "canopy_cover": 30}
+        params = {"x-api-key": api_key, "aoi[type]": "geostore", "aoi[geostore_id]": geostore, "canopy_cover": 30}
 
         response = await async_client.get(
             "/v0/land/tree_cover_loss_by_driver", headers=headers, params=params
@@ -59,7 +59,7 @@ async def test_get_tree_cover_loss_by_drivers_found(
         origin = payload["domains"][0]
 
         headers = {"origin": origin}
-        params = {"x-api-key": api_key, "aoi[geostore_id]": geostore, "canopy_cover": 30}
+        params = {"x-api-key": api_key, "aoi[type]": "geostore", "aoi[geostore_id]": geostore, "canopy_cover": 30}
         resource_id = _get_resource_id(
             "tree_cover_loss_by_driver", geostore, 30, DEFAULT_LAND_DATASET_VERSIONS
         )
@@ -94,7 +94,7 @@ async def test_get_tree_cover_loss_by_drivers_with_overrides(
         origin = payload["domains"][0]
 
         headers = {"origin": origin}
-        params = {"x-api-key": api_key, "aoi[geostore_id]": geostore, "canopy_cover": 30}
+        params = {"x-api-key": api_key, "aoi[type]": "geostore", "aoi[geostore_id]": geostore, "canopy_cover": 30}
         resource_id = _get_resource_id(
             "tree_cover_loss_by_driver",
             geostore,
@@ -140,10 +140,10 @@ async def test_get_tree_cover_loss_by_drivers_with_malformed_overrides(
     origin = payload["domains"][0]
 
     headers = {"origin": origin}
-    params = {"x-api-key": api_key, "geostore_id": geostore, "canopy_cover": 30}
+    params = {"x-api-key": api_key, "aoi[type]": "geostore", "aoi[geostore_id]": geostore, "canopy_cover": 30}
 
     response = await async_client.get(
-        f"/v0/land/tree_cover_loss_by_driver?x-api-key={api_key}&aoi[geostore_id]={geostore}&canopy_cover=30&dataset_version[umd_tree_cover_loss]]=v1.8&dataset_version[umd_tree_cover_density_2000]=v1.6",
+        f"/v0/land/tree_cover_loss_by_driver?dataset_version[umd_tree_cover_loss]]=v1.8&dataset_version[umd_tree_cover_density_2000]=v1.6",
         headers=headers,
         params=params,
     )
@@ -166,7 +166,10 @@ async def test_post_tree_cover_loss_by_drivers(
 
     headers = {"origin": origin, "x-api-key": api_key}
     payload = {
-        "aoi": {"geostore_id": geostore},
+        "aoi": {
+            "type": "geostore",
+            "geostore_id": geostore,
+        },
         "canopy_cover": 30,
         "dataset_version": {"umd_tree_cover_loss": "v1.8"},
     }

--- a/tests_v2/unit/app/routes/datamart/test_land.py
+++ b/tests_v2/unit/app/routes/datamart/test_land.py
@@ -163,7 +163,7 @@ async def test_get_tree_cover_loss_by_drivers_with_malformed_overrides(
     }
 
     response = await async_client.get(
-        f"/v0/land/tree_cover_loss_by_driver?dataset_version[umd_tree_cover_loss]]=v1.8&dataset_version[umd_tree_cover_density_2000]=v1.6",
+        "/v0/land/tree_cover_loss_by_driver?dataset_version[umd_tree_cover_loss]]=v1.8&dataset_version[umd_tree_cover_density_2000]=v1.6",
         headers=headers,
         params=params,
     )

--- a/tests_v2/unit/app/routes/datamart/test_land.py
+++ b/tests_v2/unit/app/routes/datamart/test_land.py
@@ -32,7 +32,7 @@ async def test_get_tree_cover_loss_by_drivers_not_found(
         origin = payload["domains"][0]
 
         headers = {"origin": origin}
-        params = {"x-api-key": api_key, "geostore_id": geostore, "canopy_cover": 30}
+        params = {"x-api-key": api_key, "aoi[geostore_id]": geostore, "canopy_cover": 30}
 
         response = await async_client.get(
             "/v0/land/tree_cover_loss_by_driver", headers=headers, params=params
@@ -59,7 +59,7 @@ async def test_get_tree_cover_loss_by_drivers_found(
         origin = payload["domains"][0]
 
         headers = {"origin": origin}
-        params = {"x-api-key": api_key, "geostore_id": geostore, "canopy_cover": 30}
+        params = {"x-api-key": api_key, "aoi[geostore_id]": geostore, "canopy_cover": 30}
         resource_id = _get_resource_id(
             "tree_cover_loss_by_driver", geostore, 30, DEFAULT_LAND_DATASET_VERSIONS
         )
@@ -94,7 +94,7 @@ async def test_get_tree_cover_loss_by_drivers_with_overrides(
         origin = payload["domains"][0]
 
         headers = {"origin": origin}
-        params = {"x-api-key": api_key, "geostore_id": geostore, "canopy_cover": 30}
+        params = {"x-api-key": api_key, "aoi[geostore_id]": geostore, "canopy_cover": 30}
         resource_id = _get_resource_id(
             "tree_cover_loss_by_driver",
             geostore,
@@ -143,7 +143,7 @@ async def test_get_tree_cover_loss_by_drivers_with_malformed_overrides(
     params = {"x-api-key": api_key, "geostore_id": geostore, "canopy_cover": 30}
 
     response = await async_client.get(
-        "/v0/land/tree_cover_loss_by_driver?x-api-key={api_key}&geostore_id={geostore_id}&canopy_cover=30&dataset_version[umd_tree_cover_loss]]=v1.8&dataset_version[umd_tree_cover_density_2000]=v1.6",
+        f"/v0/land/tree_cover_loss_by_driver?x-api-key={api_key}&aoi[geostore_id]={geostore}&canopy_cover=30&dataset_version[umd_tree_cover_loss]]=v1.8&dataset_version[umd_tree_cover_density_2000]=v1.6",
         headers=headers,
         params=params,
     )
@@ -166,7 +166,7 @@ async def test_post_tree_cover_loss_by_drivers(
 
     headers = {"origin": origin, "x-api-key": api_key}
     payload = {
-        "geostore_id": geostore,
+        "aoi": {"geostore_id": geostore},
         "canopy_cover": 30,
         "dataset_version": {"umd_tree_cover_loss": "v1.8"},
     }

--- a/tests_v2/unit/app/routes/datamart/test_land.py
+++ b/tests_v2/unit/app/routes/datamart/test_land.py
@@ -32,7 +32,12 @@ async def test_get_tree_cover_loss_by_drivers_not_found(
         origin = payload["domains"][0]
 
         headers = {"origin": origin}
-        params = {"x-api-key": api_key, "aoi[type]": "geostore", "aoi[geostore_id]": geostore, "canopy_cover": 30}
+        params = {
+            "x-api-key": api_key,
+            "aoi[type]": "geostore",
+            "aoi[geostore_id]": geostore,
+            "canopy_cover": 30,
+        }
 
         response = await async_client.get(
             "/v0/land/tree_cover_loss_by_driver", headers=headers, params=params
@@ -59,7 +64,12 @@ async def test_get_tree_cover_loss_by_drivers_found(
         origin = payload["domains"][0]
 
         headers = {"origin": origin}
-        params = {"x-api-key": api_key, "aoi[type]": "geostore", "aoi[geostore_id]": geostore, "canopy_cover": 30}
+        params = {
+            "x-api-key": api_key,
+            "aoi[type]": "geostore",
+            "aoi[geostore_id]": geostore,
+            "canopy_cover": 30,
+        }
         resource_id = _get_resource_id(
             "tree_cover_loss_by_driver", geostore, 30, DEFAULT_LAND_DATASET_VERSIONS
         )
@@ -94,7 +104,12 @@ async def test_get_tree_cover_loss_by_drivers_with_overrides(
         origin = payload["domains"][0]
 
         headers = {"origin": origin}
-        params = {"x-api-key": api_key, "aoi[type]": "geostore", "aoi[geostore_id]": geostore, "canopy_cover": 30}
+        params = {
+            "x-api-key": api_key,
+            "aoi[type]": "geostore",
+            "aoi[geostore_id]": geostore,
+            "canopy_cover": 30,
+        }
         resource_id = _get_resource_id(
             "tree_cover_loss_by_driver",
             geostore,
@@ -140,7 +155,12 @@ async def test_get_tree_cover_loss_by_drivers_with_malformed_overrides(
     origin = payload["domains"][0]
 
     headers = {"origin": origin}
-    params = {"x-api-key": api_key, "aoi[type]": "geostore", "aoi[geostore_id]": geostore, "canopy_cover": 30}
+    params = {
+        "x-api-key": api_key,
+        "aoi[type]": "geostore",
+        "aoi[geostore_id]": geostore,
+        "canopy_cover": 30,
+    }
 
     response = await async_client.get(
         f"/v0/land/tree_cover_loss_by_driver?dataset_version[umd_tree_cover_loss]]=v1.8&dataset_version[umd_tree_cover_density_2000]=v1.6",
@@ -403,20 +423,30 @@ MOCK_ERROR_RESOURCE = {
 class TestAdminAreaOfInterest:
     @pytest.mark.asyncio
     async def test_get_tree_cover_loss_by_drivers_found(
-            self,
-            geostore,
-            apikey,
-            async_client: AsyncClient,
+        self,
+        geostore,
+        apikey,
+        async_client: AsyncClient,
     ):
         with (
-            patch("app.routes.datamart.land._get_resource", return_value=None) as mock_get_resources,
-            patch("app.models.pydantic.datamart.get_gadm_geostore_id", return_value=geostore)
+            patch(
+                "app.routes.datamart.land._get_resource", return_value=None
+            ) as mock_get_resources,
+            patch(
+                "app.models.pydantic.datamart.get_gadm_geostore_id",
+                return_value=geostore,
+            ),
         ):
             api_key, payload = apikey
             origin = payload["domains"][0]
 
             headers = {"origin": origin}
-            params = {"x-api-key": api_key, "aoi[type]": "admin", "aoi[country]": "BRA", "canopy_cover": 30}
+            params = {
+                "x-api-key": api_key,
+                "aoi[type]": "admin",
+                "aoi[country]": "BRA",
+                "canopy_cover": 30,
+            }
             resource_id = _get_resource_id(
                 "tree_cover_loss_by_driver", geostore, 30, DEFAULT_LAND_DATASET_VERSIONS
             )
@@ -427,7 +457,7 @@ class TestAdminAreaOfInterest:
 
             assert response.status_code == 200
             assert (
-                    f"/v0/land/tree_cover_loss_by_driver/{resource_id}"
-                    in response.json()["data"]["link"]
+                f"/v0/land/tree_cover_loss_by_driver/{resource_id}"
+                in response.json()["data"]["link"]
             )
             mock_get_resources.assert_awaited_with(resource_id)


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [x] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type
Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
Administrative boundary areas are not supported. The client must have a geostore ID

Issue Number: GTC-3172


## What is the new behavior?
Clients can now use Administrative Boundaries with requests.

GET (query parameters):
`aoi[type]=admin&aoi[country]=BRA&aoi[region]=12&aoi[subregion]=23`

POST (body):
```json
{
  "aoi": {
    "type": "admin",
    "country": "BRA",
    "region": "12",
    "subregion": "23"
  }
}
```
### NOTE
There is now a grouping parameter (`aoi`) and a discriminator (`aoi[type]`)
The discriminator makes for very nice openapi documentation and allows much richer validation for pydantic unions
https://docs.pydantic.dev/latest/concepts/unions/#discriminated-unions

**Only GADM 4.1 is currently supported**

## Does this introduce a breaking change?

- [x] Yes
- [ ] No
