### PR TITLE
Gtc 3187/datamart global analysis

### DIFF
--- a/app/crud/geostore.py
+++ b/app/crud/geostore.py
@@ -9,7 +9,6 @@ from sqlalchemy.sql import Select, label
 from sqlalchemy.sql.elements import Label, TextClause
 
 from app.application import db
-from app.crud.tasks import create_or_update_task
 from app.errors import (
     BadAdminSourceException,
     BadAdminVersionException,

--- a/app/crud/geostore.py
+++ b/app/crud/geostore.py
@@ -191,6 +191,27 @@ async def get_first_row(sql: Select):
     return row
 
 
+async def get_gadm_geostore_id(
+        admin_provider: str,
+        admin_version: str,
+        adm_level: int,
+        country_id: str,
+        region_id: str | None = None,
+        subregion_id: str | None = None,
+) -> str:
+    src_table = await get_versioned_dataset(admin_provider, admin_version)
+    columns_etc: List[Column | Label] = [db.column("gfw_geostore_id"),]
+    sql: Select = db.select(columns_etc).select_from(src_table)
+    sql = await add_where_clauses(adm_level, admin_provider, admin_version, country_id, region_id, sql, subregion_id)
+    row = await get_first_row(sql)
+    if row is None:
+        raise RecordNotFoundError(
+            f"Admin boundary not found in {admin_provider} version {admin_version}"
+        )
+
+    return await row.gfw_geostore_id
+
+
 async def build_gadm_geostore(
     admin_provider: str,
     admin_version: str,

--- a/app/models/pydantic/datamart.py
+++ b/app/models/pydantic/datamart.py
@@ -62,7 +62,10 @@ class AdminAreaOfInterest(AreaOfInterest):
 
 
 class Global(AreaOfInterest):
-    type: Literal["global"] = "global"
+    type: Literal["global"] = Field(
+        "global",
+        description="Apply analysis to the full spatial extent of the dataset."
+    )
 
 
 class AnalysisStatus(str, Enum):

--- a/app/models/pydantic/datamart.py
+++ b/app/models/pydantic/datamart.py
@@ -8,7 +8,7 @@ from pydantic import Field
 from app.models.pydantic.responses import Response
 
 from .base import StrictBaseModel
-from ...crud.geostore import build_gadm_geostore
+from ...crud.geostore import get_gadm_geostore_id
 
 
 class AreaOfInterest(StrictBaseModel, ABC):
@@ -35,16 +35,15 @@ class AdminAreaOfInterest(AreaOfInterest):
 
     async def get_geostore_id(self) -> UUID:
         admin_level = sum(1 for field in (self.country, self.region, self.subregion) if field is not None) - 1
-        geostore = await build_gadm_geostore(
+        geostore_id = await get_gadm_geostore_id(
             admin_provider=self.provider,
             admin_version=self.version,
             adm_level=admin_level,
-            simplify=None,
             country_id=self.country,
             region_id=self.region,
             subregion_id=self.subregion,
         )
-        return UUID(geostore.id)
+        return UUID(geostore_id)
 
 
 class AnalysisStatus(str, Enum):

--- a/app/models/pydantic/datamart.py
+++ b/app/models/pydantic/datamart.py
@@ -87,7 +87,7 @@ class DataMartSource(StrictBaseModel):
 
 
 class DataMartMetadata(StrictBaseModel):
-    geostore_id: UUID
+    aoi: Union[GeostoreAreaOfInterest, AdminAreaOfInterest, Global]
     sources: list[DataMartSource]
 
 
@@ -137,7 +137,6 @@ class TreeCoverLossByDriverUpdate(StrictBaseModel):
     result: Optional[List[Dict[str, Any]]] = Field(
         None, alias="tree_cover_loss_by_driver"
     )
-    metadata: Optional[TreeCoverLossByDriverMetadata] = None
     status: Optional[AnalysisStatus] = AnalysisStatus.saved
     message: Optional[str] = None
 

--- a/app/models/pydantic/datamart.py
+++ b/app/models/pydantic/datamart.py
@@ -13,7 +13,7 @@ from ...crud.geostore import get_gadm_geostore_id
 class AreaOfInterest(StrictBaseModel):
     async def get_geostore_id(self) -> UUID:
         """Return the unique identifier for the area of interest."""
-        pass
+        raise NotImplementedError("This method is not implemented.")
 
 
 class GeostoreAreaOfInterest(AreaOfInterest):

--- a/app/models/pydantic/datamart.py
+++ b/app/models/pydantic/datamart.py
@@ -1,12 +1,26 @@
 from enum import Enum
-from typing import Dict, Optional
+from typing import Dict, Optional, Union
 from uuid import UUID
+from abc import ABC, abstractmethod
 
 from pydantic import Field
 
 from app.models.pydantic.responses import Response
 
 from .base import StrictBaseModel
+
+class AreaOfInterest(StrictBaseModel, ABC):
+    @abstractmethod
+    def get_geostore_id(self) -> UUID:
+        """Return the unique identifier for the area of interest."""
+        pass
+
+
+class GeostoreAreaOfInterest(AreaOfInterest):
+    geostore_id:UUID = Field(..., title="Geostore ID")
+
+    def get_geostore_id(self) -> UUID:
+        return self.geostore_id
 
 
 class AnalysisStatus(str, Enum):
@@ -43,7 +57,7 @@ class DataMartResourceLinkResponse(Response):
 
 
 class TreeCoverLossByDriverIn(StrictBaseModel):
-    geostore_id: UUID
+    aoi: Union[GeostoreAreaOfInterest]
     canopy_cover: int = 30
     dataset_version: Dict[str, str] = {}
 
@@ -76,3 +90,6 @@ class TreeCoverLossByDriverUpdate(StrictBaseModel):
 
 class TreeCoverLossByDriverResponse(Response):
     data: TreeCoverLossByDriver
+
+
+

--- a/app/models/pydantic/datamart.py
+++ b/app/models/pydantic/datamart.py
@@ -17,7 +17,7 @@ class AreaOfInterest(StrictBaseModel):
 
 
 class GeostoreAreaOfInterest(AreaOfInterest):
-    type: Literal['geostore'] = 'geostore'
+    type: Literal["geostore"] = "geostore"
     geostore_id: UUID = Field(..., title="Geostore ID")
 
     async def get_geostore_id(self) -> UUID:
@@ -25,15 +25,22 @@ class GeostoreAreaOfInterest(AreaOfInterest):
 
 
 class AdminAreaOfInterest(AreaOfInterest):
-    type: Literal['admin'] = 'admin'
+    type: Literal["admin"] = "admin"
     country: str = Field(..., title="ISO Country Code")
     region: Optional[str] = Field(None, title="Region")
     subregion: Optional[str] = Field(None, title="Subregion")
-    provider: str = Field('gadm', title="Administrative Boundary Provider")
-    version: str = Field('4.1', title="Administrative Boundary Version")
+    provider: str = Field("gadm", title="Administrative Boundary Provider")
+    version: str = Field("4.1", title="Administrative Boundary Version")
 
     async def get_geostore_id(self) -> UUID:
-        admin_level = sum(1 for field in (self.country, self.region, self.subregion) if field is not None) - 1
+        admin_level = (
+            sum(
+                1
+                for field in (self.country, self.region, self.subregion)
+                if field is not None
+            )
+            - 1
+        )
         geostore_id = await get_gadm_geostore_id(
             admin_provider=self.provider,
             admin_version=self.version,
@@ -52,19 +59,19 @@ class AdminAreaOfInterest(AreaOfInterest):
             raise ValueError("region must be specified if subregion is provided")
         return values
 
-    @validator('provider', pre=True, always=True)
+    @validator("provider", pre=True, always=True)
     def set_provider_default(cls, v):
-        return v or 'gadm'
+        return v or "gadm"
 
-    @validator('version', pre=True, always=True)
+    @validator("version", pre=True, always=True)
     def set_version_default(cls, v):
-        return v or '4.1'
+        return v or "4.1"
 
 
 class Global(AreaOfInterest):
     type: Literal["global"] = Field(
         "global",
-        description="Apply analysis to the full spatial extent of the dataset."
+        description="Apply analysis to the full spatial extent of the dataset.",
     )
 
 
@@ -102,7 +109,9 @@ class DataMartResourceLinkResponse(Response):
 
 
 class TreeCoverLossByDriverIn(StrictBaseModel):
-    aoi: Union[GeostoreAreaOfInterest, AdminAreaOfInterest, Global] = Field(..., discriminator='type')
+    aoi: Union[GeostoreAreaOfInterest, AdminAreaOfInterest, Global] = Field(
+        ..., discriminator="type"
+    )
     canopy_cover: int = 30
     dataset_version: Dict[str, str] = {}
 

--- a/app/routes/datamart/land.py
+++ b/app/routes/datamart/land.py
@@ -73,26 +73,30 @@ def _parse_dataset_versions(request: Request) -> Dict[str, str]:
 
 def _parse_area_of_interest(request: Request) -> AreaOfInterest:
     params = request.query_params
-    aoi_type = params.get('aoi[type]')
+    aoi_type = params.get("aoi[type]")
     try:
-        if aoi_type == 'geostore':
-            return GeostoreAreaOfInterest(geostore_id=params.get('aoi[geostore_id]', None))
+        if aoi_type == "geostore":
+            return GeostoreAreaOfInterest(
+                geostore_id=params.get("aoi[geostore_id]", None)
+            )
 
             # Otherwise, check if the request contains admin area information
-        if aoi_type == 'admin':
+        if aoi_type == "admin":
             return AdminAreaOfInterest(
-                country=params.get('aoi[country]', None),
-                region=params.get('aoi[region]', None),
-                subregion=params.get('aoi[subregion]', None),
-                provider=params.get('aoi[provider]', None),
-                version=params.get('aoi[version]', None),
+                country=params.get("aoi[country]", None),
+                region=params.get("aoi[region]", None),
+                subregion=params.get("aoi[subregion]", None),
+                provider=params.get("aoi[provider]", None),
+                version=params.get("aoi[version]", None),
             )
 
         if aoi_type == "global":
             return Global()
 
         # If neither type is provided, raise an error
-        raise HTTPException(status_code=422, detail="Invalid Area of Interest parameters")
+        raise HTTPException(
+            status_code=422, detail="Invalid Area of Interest parameters"
+        )
     except ValidationError as e:
         raise HTTPException(status_code=422, detail=e.errors())
 
@@ -169,7 +173,9 @@ async def tree_cover_loss_by_driver_post(
     """Create new tree cover loss by drivers resource for a given geostore and
     canopy cover."""
 
-    area_id = "global" if data.aoi.type == "global" else await data.aoi.get_geostore_id()
+    area_id = (
+        "global" if data.aoi.type == "global" else await data.aoi.get_geostore_id()
+    )
 
     dataset_version = DEFAULT_LAND_DATASET_VERSIONS | data.dataset_version
     resource_id = _get_resource_id(
@@ -188,7 +194,7 @@ async def tree_cover_loss_by_driver_post(
         except HTTPException:
             raise HTTPException(
                 HTTP_400_BAD_REQUEST,
-                detail="Global computation not supported for this dataset and pre-computed results are not available."
+                detail="Global computation not supported for this dataset and pre-computed results are not available.",
             )
 
         return DataMartResourceLinkResponse(data=link)

--- a/app/routes/datamart/land.py
+++ b/app/routes/datamart/land.py
@@ -246,9 +246,6 @@ async def _get_resource(resource_id):
         )
 
 
-
-
-
 async def _save_pending_resource(resource_id, endpoint, api_key):
     pending_resource = DataMartResource(
         id=resource_id,

--- a/app/tasks/datamart/land.py
+++ b/app/tasks/datamart/land.py
@@ -7,8 +7,6 @@ import app.crud.datamart as datamart_crud
 from app.models.enum.geostore import GeostoreOrigin
 from app.models.pydantic.datamart import (
     AnalysisStatus,
-    DataMartSource,
-    TreeCoverLossByDriverMetadata,
     TreeCoverLossByDriverUpdate,
 )
 from app.models.pydantic.geostore import GeostoreCommon
@@ -29,9 +27,6 @@ async def compute_tree_cover_loss_by_driver(
     dataset_version: Dict[str, str],
 ):
 
-    resource = TreeCoverLossByDriverUpdate(
-        metadata=_get_metadata(geostore_id, canopy_cover, dataset_version),
-    )
     try:
         logger.info(
             f"Computing tree cover loss by driver for resource {resource_id} with geostore {geostore_id} and canopy cover {canopy_cover}"
@@ -55,29 +50,18 @@ async def compute_tree_cover_loss_by_driver(
             for row in results
         ]
 
-        resource.result = tcl_by_driver
-        resource.status = AnalysisStatus.saved
+        resource = TreeCoverLossByDriverUpdate(
+            result=tcl_by_driver,
+            status=AnalysisStatus.saved,
+        )
         await datamart_crud.update_result(resource_id, resource)
 
     except Exception as e:
         logger.error(
             f"Tree cover loss by drivers analysis failed for geostore ${geostore_id} with error: {e}"
         )
-        resource.status = AnalysisStatus.failed
-        resource.message = str(e)
+        resource = TreeCoverLossByDriverUpdate(
+            status=AnalysisStatus.failed, message=str(e)
+        )
 
         await datamart_crud.update_result(resource_id, resource)
-
-
-def _get_metadata(
-    geostore_id: UUID, canopy_cover: int, dataset_version: Dict[str, str]
-):
-    sources = [
-        DataMartSource(dataset=dataset, version=version)
-        for dataset, version in dataset_version.items()
-    ]
-    return TreeCoverLossByDriverMetadata(
-        geostore_id=geostore_id,
-        canopy_cover=canopy_cover,
-        sources=sources,
-    )

--- a/tests_v2/unit/app/crud/test_geostore.py
+++ b/tests_v2/unit/app/crud/test_geostore.py
@@ -3,13 +3,13 @@ from unittest.mock import patch
 import pytest
 from httpx import AsyncClient
 
-from app.crud.geostore import get_gadm_geostore
+from app.crud.geostore import get_gadm_geostore, get_gadm_geostore_id
 from app.errors import RecordNotFoundError
 
 
 @pytest.mark.asyncio
 async def test_get_gadm_geostore_generates_correct_sql_for_country_lookup(
-    async_client: AsyncClient
+        async_client: AsyncClient
 ):
     provider = "gadm"
     version = "4.1"
@@ -45,7 +45,7 @@ async def test_get_gadm_geostore_generates_correct_sql_for_country_lookup(
 
 @pytest.mark.asyncio
 async def test_get_gadm_geostore_generates_correct_sql_for_region_lookup(
-    async_client: AsyncClient
+        async_client: AsyncClient
 ):
     provider = "gadm"
     version = "4.1"
@@ -80,10 +80,9 @@ async def test_get_gadm_geostore_generates_correct_sql_for_region_lookup(
     assert actual_sql == expected_sql
 
 
-
 @pytest.mark.asyncio
 async def test_get_gadm_geostore_generates_correct_sql_for_subregion_lookup(
-    async_client: AsyncClient
+        async_client: AsyncClient
 ):
     provider = "gadm"
     version = "4.1"
@@ -117,3 +116,109 @@ async def test_get_gadm_geostore_generates_correct_sql_for_subregion_lookup(
 
     assert mock_get_first_row.called is True
     assert actual_sql == expected_sql
+
+
+class TestGadmGeostoreIDLookup:
+    @pytest.mark.asyncio
+    async def test_get_gadm_geostore_id_generates_correct_sql_for_country_lookup(
+            async_client: AsyncClient
+    ):
+        provider = "gadm"
+        version = "4.1"
+        adm_level = 0
+        country_id = "MEX"
+
+        with patch("app.crud.geostore.get_first_row") as mock_get_first_row:
+            mock_get_first_row.return_value = None
+            try:
+                _ = await get_gadm_geostore_id(
+                    provider, version, adm_level, country_id, None, None
+                )
+            except RecordNotFoundError:
+                pass
+
+        expected_sql = (
+            "SELECT gfw_geostore_id "
+            '\nFROM gadm_administrative_boundaries."v4.1.64" \n'
+            "WHERE adm_level='0' AND gid_0='MEX'"
+        )
+
+        actual_sql = str(
+            mock_get_first_row.call_args.args[0].compile(
+                compile_kwargs={"literal_binds": True}
+            )
+        )
+
+        assert mock_get_first_row.called is True
+        assert actual_sql == expected_sql
+
+
+    @pytest.mark.asyncio
+    async def test_get_gadm_geostore_id_generates_correct_sql_for_region_lookup(
+            async_client: AsyncClient
+    ):
+        provider = "gadm"
+        version = "4.1"
+        adm_level = 1
+        country = "MEX"
+        region = "5"
+
+        with patch("app.crud.geostore.get_first_row") as mock_get_first_row:
+            mock_get_first_row.return_value = None
+            try:
+                _ = await get_gadm_geostore_id(
+                    provider, version, adm_level, country, region, None
+                )
+            except RecordNotFoundError:
+                pass
+
+        expected_sql = (
+            "SELECT gfw_geostore_id "
+            '\nFROM gadm_administrative_boundaries."v4.1.64" \n'
+            r"WHERE adm_level='1' AND gid_1 LIKE 'MEX.5\__'"
+        )
+
+        actual_sql = str(
+            mock_get_first_row.call_args.args[0].compile(
+                compile_kwargs={"literal_binds": True}
+            )
+        )
+
+        assert mock_get_first_row.called is True
+        assert actual_sql == expected_sql
+
+
+    @pytest.mark.asyncio
+    async def test_get_gadm_geostore_id_generates_correct_sql_for_subregion_lookup(
+            async_client: AsyncClient
+    ):
+        provider = "gadm"
+        version = "4.1"
+        adm_level = 2
+        country = "MEX"
+        region = "5"
+        subregion = "2"
+
+        with patch("app.crud.geostore.get_first_row") as mock_get_first_row:
+            mock_get_first_row.return_value = None
+            try:
+                _ = await get_gadm_geostore_id(
+                    provider, version, adm_level, country, region, subregion
+                )
+            except RecordNotFoundError:
+                pass
+
+        expected_sql = (
+            "SELECT gfw_geostore_id "
+            '\nFROM gadm_administrative_boundaries."v4.1.64" \n'
+            r"WHERE adm_level='2' AND gid_2 LIKE 'MEX.5.2\__'"
+        )
+
+        actual_sql = str(
+            mock_get_first_row.call_args.args[0].compile(
+                compile_kwargs={"literal_binds": True}
+            )
+        )
+
+        assert mock_get_first_row.called is True
+        assert actual_sql == expected_sql

--- a/tests_v2/unit/app/routes/datamart/test_land.py
+++ b/tests_v2/unit/app/routes/datamart/test_land.py
@@ -398,3 +398,36 @@ MOCK_ERROR_RESOURCE = {
         ],
     },
 }
+
+
+class TestAdminAreaOfInterest:
+    @pytest.mark.asyncio
+    async def test_get_tree_cover_loss_by_drivers_found(
+            self,
+            geostore,
+            apikey,
+            async_client: AsyncClient,
+    ):
+        with (
+            patch("app.routes.datamart.land._get_resource", return_value=None) as mock_get_resources,
+            patch("app.models.pydantic.datamart.get_gadm_geostore_id", return_value=geostore)
+        ):
+            api_key, payload = apikey
+            origin = payload["domains"][0]
+
+            headers = {"origin": origin}
+            params = {"x-api-key": api_key, "aoi[type]": "admin", "aoi[country]": "BRA", "canopy_cover": 30}
+            resource_id = _get_resource_id(
+                "tree_cover_loss_by_driver", geostore, 30, DEFAULT_LAND_DATASET_VERSIONS
+            )
+
+            response = await async_client.get(
+                "/v0/land/tree_cover_loss_by_driver", headers=headers, params=params
+            )
+
+            assert response.status_code == 200
+            assert (
+                    f"/v0/land/tree_cover_loss_by_driver/{resource_id}"
+                    in response.json()["data"]["link"]
+            )
+            mock_get_resources.assert_awaited_with(resource_id)

--- a/tests_v2/unit/app/routes/datamart/test_land.py
+++ b/tests_v2/unit/app/routes/datamart/test_land.py
@@ -32,7 +32,7 @@ async def test_get_tree_cover_loss_by_drivers_not_found(
         origin = payload["domains"][0]
 
         headers = {"origin": origin}
-        params = {"x-api-key": api_key, "aoi[geostore_id]": geostore, "canopy_cover": 30}
+        params = {"x-api-key": api_key, "aoi[type]": "geostore", "aoi[geostore_id]": geostore, "canopy_cover": 30}
 
         response = await async_client.get(
             "/v0/land/tree_cover_loss_by_driver", headers=headers, params=params
@@ -59,7 +59,7 @@ async def test_get_tree_cover_loss_by_drivers_found(
         origin = payload["domains"][0]
 
         headers = {"origin": origin}
-        params = {"x-api-key": api_key, "aoi[geostore_id]": geostore, "canopy_cover": 30}
+        params = {"x-api-key": api_key, "aoi[type]": "geostore", "aoi[geostore_id]": geostore, "canopy_cover": 30}
         resource_id = _get_resource_id(
             "tree_cover_loss_by_driver", geostore, 30, DEFAULT_LAND_DATASET_VERSIONS
         )
@@ -94,7 +94,7 @@ async def test_get_tree_cover_loss_by_drivers_with_overrides(
         origin = payload["domains"][0]
 
         headers = {"origin": origin}
-        params = {"x-api-key": api_key, "aoi[geostore_id]": geostore, "canopy_cover": 30}
+        params = {"x-api-key": api_key, "aoi[type]": "geostore", "aoi[geostore_id]": geostore, "canopy_cover": 30}
         resource_id = _get_resource_id(
             "tree_cover_loss_by_driver",
             geostore,
@@ -140,10 +140,10 @@ async def test_get_tree_cover_loss_by_drivers_with_malformed_overrides(
     origin = payload["domains"][0]
 
     headers = {"origin": origin}
-    params = {"x-api-key": api_key, "geostore_id": geostore, "canopy_cover": 30}
+    params = {"x-api-key": api_key, "aoi[type]": "geostore", "aoi[geostore_id]": geostore, "canopy_cover": 30}
 
     response = await async_client.get(
-        f"/v0/land/tree_cover_loss_by_driver?x-api-key={api_key}&aoi[geostore_id]={geostore}&canopy_cover=30&dataset_version[umd_tree_cover_loss]]=v1.8&dataset_version[umd_tree_cover_density_2000]=v1.6",
+        f"/v0/land/tree_cover_loss_by_driver?dataset_version[umd_tree_cover_loss]]=v1.8&dataset_version[umd_tree_cover_density_2000]=v1.6",
         headers=headers,
         params=params,
     )
@@ -166,7 +166,10 @@ async def test_post_tree_cover_loss_by_drivers(
 
     headers = {"origin": origin, "x-api-key": api_key}
     payload = {
-        "aoi": {"geostore_id": geostore},
+        "aoi": {
+            "type": "geostore",
+            "geostore_id": geostore,
+        },
         "canopy_cover": 30,
         "dataset_version": {"umd_tree_cover_loss": "v1.8"},
     }

--- a/tests_v2/unit/app/routes/datamart/test_land.py
+++ b/tests_v2/unit/app/routes/datamart/test_land.py
@@ -478,20 +478,23 @@ class TestAdminAreaOfInterest:
 
             assert response.status_code == 200
             assert (
-                    f"/v0/land/tree_cover_loss_by_driver/{resource_id}"
-                    in response.json()["data"]["link"]
+                f"/v0/land/tree_cover_loss_by_driver/{resource_id}"
+                in response.json()["data"]["link"]
             )
             mock_get_resources.assert_awaited_with(resource_id)
+
 
 class TestGlobal:
     @pytest.mark.asyncio
     async def test_get_tree_cover_loss_by_drivers_found(
-            self,
-            apikey,
-            async_client: AsyncClient,
+        self,
+        apikey,
+        async_client: AsyncClient,
     ):
         with (
-            patch("app.routes.datamart.land._get_resource", return_value=None) as mock_get_resources,
+            patch(
+                "app.routes.datamart.land._get_resource", return_value=None
+            ) as mock_get_resources,
         ):
             api_key, payload = apikey
             origin = payload["domains"][0]
@@ -508,11 +511,10 @@ class TestGlobal:
 
             assert response.status_code == 200
             assert (
-                    f"/v0/land/tree_cover_loss_by_driver/{resource_id}"
-                    in response.json()["data"]["link"]
+                f"/v0/land/tree_cover_loss_by_driver/{resource_id}"
+                in response.json()["data"]["link"]
             )
             mock_get_resources.assert_awaited_with(resource_id)
-
 
     @pytest.mark.asyncio
     async def test_post_tree_cover_loss_by_drivers(
@@ -532,7 +534,9 @@ class TestGlobal:
             "dataset_version": {"umd_tree_cover_loss": "v1.8"},
         }
         with (
-            patch("app.routes.datamart.land._get_resource", return_value=None) as mock_get_resources,
+            patch(
+                "app.routes.datamart.land._get_resource", return_value=None
+            ) as mock_get_resources,
         ):
             response = await async_client.post(
                 "/v0/land/tree_cover_loss_by_driver", headers=headers, json=payload

--- a/tests_v2/unit/app/routes/datamart/test_land.py
+++ b/tests_v2/unit/app/routes/datamart/test_land.py
@@ -32,7 +32,7 @@ async def test_get_tree_cover_loss_by_drivers_not_found(
         origin = payload["domains"][0]
 
         headers = {"origin": origin}
-        params = {"x-api-key": api_key, "geostore_id": geostore, "canopy_cover": 30}
+        params = {"x-api-key": api_key, "aoi[geostore_id]": geostore, "canopy_cover": 30}
 
         response = await async_client.get(
             "/v0/land/tree_cover_loss_by_driver", headers=headers, params=params
@@ -59,7 +59,7 @@ async def test_get_tree_cover_loss_by_drivers_found(
         origin = payload["domains"][0]
 
         headers = {"origin": origin}
-        params = {"x-api-key": api_key, "geostore_id": geostore, "canopy_cover": 30}
+        params = {"x-api-key": api_key, "aoi[geostore_id]": geostore, "canopy_cover": 30}
         resource_id = _get_resource_id(
             "tree_cover_loss_by_driver", geostore, 30, DEFAULT_LAND_DATASET_VERSIONS
         )
@@ -94,7 +94,7 @@ async def test_get_tree_cover_loss_by_drivers_with_overrides(
         origin = payload["domains"][0]
 
         headers = {"origin": origin}
-        params = {"x-api-key": api_key, "geostore_id": geostore, "canopy_cover": 30}
+        params = {"x-api-key": api_key, "aoi[geostore_id]": geostore, "canopy_cover": 30}
         resource_id = _get_resource_id(
             "tree_cover_loss_by_driver",
             geostore,
@@ -143,7 +143,7 @@ async def test_get_tree_cover_loss_by_drivers_with_malformed_overrides(
     params = {"x-api-key": api_key, "geostore_id": geostore, "canopy_cover": 30}
 
     response = await async_client.get(
-        "/v0/land/tree_cover_loss_by_driver?x-api-key={api_key}&geostore_id={geostore_id}&canopy_cover=30&dataset_version[umd_tree_cover_loss]]=v1.8&dataset_version[umd_tree_cover_density_2000]=v1.6",
+        f"/v0/land/tree_cover_loss_by_driver?x-api-key={api_key}&aoi[geostore_id]={geostore}&canopy_cover=30&dataset_version[umd_tree_cover_loss]]=v1.8&dataset_version[umd_tree_cover_density_2000]=v1.6",
         headers=headers,
         params=params,
     )
@@ -166,7 +166,7 @@ async def test_post_tree_cover_loss_by_drivers(
 
     headers = {"origin": origin, "x-api-key": api_key}
     payload = {
-        "geostore_id": geostore,
+        "aoi": {"geostore_id": geostore},
         "canopy_cover": 30,
         "dataset_version": {"umd_tree_cover_loss": "v1.8"},
     }

--- a/tests_v2/unit/app/routes/datamart/test_land.py
+++ b/tests_v2/unit/app/routes/datamart/test_land.py
@@ -539,7 +539,7 @@ class TestGlobal:
     ):
         with (
             patch(
-                "app.routes.datamart.land._get_resource", return_value=None
+                "app.routes.datamart.land._check_resource_exists", return_value=True
             ) as mock_get_resources,
         ):
             api_key, payload = apikey


### PR DESCRIPTION
This adds to TCL by drivers data mart endpoint a way to serve pre-computed global results.
This is based on Gary's data mart admin AOI support PR and will be updated accordingly.