### PR TITLE
Flatten response from datamart

### DIFF
--- a/app/models/pydantic/datamart.py
+++ b/app/models/pydantic/datamart.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from enum import Enum
-from typing import Dict, Literal, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 from uuid import UUID
 
 from pydantic import Field, root_validator, validator
@@ -116,7 +116,9 @@ class TreeCoverLossByDriverMetadata(DataMartMetadata):
 
 
 class TreeCoverLossByDriver(StrictBaseModel):
-    result: Optional[Dict[str, float]] = Field(None, alias="tree_cover_loss_by_driver")
+    result: Optional[List[Dict[str, Any]]] = Field(
+        None, alias="tree_cover_loss_by_driver"
+    )
     metadata: Optional[TreeCoverLossByDriverMetadata] = None
     message: Optional[str] = None
     status: AnalysisStatus
@@ -127,7 +129,9 @@ class TreeCoverLossByDriver(StrictBaseModel):
 
 
 class TreeCoverLossByDriverUpdate(StrictBaseModel):
-    result: Optional[Dict[str, float]] = Field(None, alias="tree_cover_loss_by_driver")
+    result: Optional[List[Dict[str, Any]]] = Field(
+        None, alias="tree_cover_loss_by_driver"
+    )
     metadata: Optional[TreeCoverLossByDriverMetadata] = None
     status: Optional[AnalysisStatus] = AnalysisStatus.saved
     message: Optional[str] = None

--- a/app/tasks/datamart/land.py
+++ b/app/tasks/datamart/land.py
@@ -47,10 +47,13 @@ async def compute_tree_cover_loss_by_driver(
             dataset_version,
         )
 
-        tcl_by_driver = {
-            row["tsc_tree_cover_loss_drivers__driver"]: row["area__ha"]
+        tcl_by_driver = [
+            {
+                "drivers_type": row["tsc_tree_cover_loss_drivers__driver"],
+                "loss_area_ha": row["area__ha"],
+            }
             for row in results
-        }
+        ]
 
         resource.result = tcl_by_driver
         resource.status = AnalysisStatus.saved

--- a/tests_v2/unit/app/routes/datamart/test_land.py
+++ b/tests_v2/unit/app/routes/datamart/test_land.py
@@ -384,15 +384,36 @@ MOCK_RESULT = [
 MOCK_RESOURCE = {
     "status": "saved",
     "message": None,
-    "tree_cover_loss_by_driver": {
-        "Permanent agriculture": 10.0,
-        "Hard commodities": 12.0,
-        "Shifting cultivation": 7.0,
-        "Forest management": 93.4,
-        "Wildfires": 42.0,
-        "Settlements and infrastructure": 13.562,
-        "Other natural disturbances": 6.0,
-    },
+    "tree_cover_loss_by_driver": [
+        {
+            "drivers_type": "Permanent agriculture",
+            "loss_area_ha": 10,
+        },
+        {
+            "drivers_type": "Hard commodities",
+            "loss_area_ha": 12,
+        },
+        {
+            "drivers_type": "Shifting cultivation",
+            "loss_area_ha": 7,
+        },
+        {
+            "drivers_type": "Forest management",
+            "loss_area_ha": 93.4,
+        },
+        {
+            "drivers_type": "Wildfires",
+            "loss_area_ha": 42,
+        },
+        {
+            "drivers_type": "Settlements and infrastructure",
+            "loss_area_ha": 13.562,
+        },
+        {
+            "drivers_type": "Other natural disturbances",
+            "loss_area_ha": 6,
+        },
+    ],
     "metadata": {
         "geostore_id": "",
         "canopy_cover": 30,


### PR DESCRIPTION
Instead of returning a dictionary of the results, return a flattened response like:

```
"yearly_tree_cover_loss_by_driver": [
    {
      "drivers_type": "Forest Management",
      "loss_area_ha": 1024.34,
    },
    {
      "drivers_type": "Wildlife",
      "loss_area_ha": 1024.34
    }
]
```

