### PR TITLE
Return 409 for POST on existing resource, don't convert UUID to UUID

### DIFF
--- a/app/models/pydantic/datamart.py
+++ b/app/models/pydantic/datamart.py
@@ -51,7 +51,7 @@ class AdminAreaOfInterest(AreaOfInterest):
             region_id=self.region,
             subregion_id=self.subregion,
         )
-        return UUID(geostore_id)
+        return geostore_id
 
     @root_validator
     def check_region_subregion(cls, values):

--- a/app/routes/datamart/land.py
+++ b/app/routes/datamart/land.py
@@ -117,7 +117,12 @@ async def tree_cover_loss_by_driver_search(
     )
 
     # check if it exists
-    await _get_resource(resource_id)
+    resource_exists = await _check_resource_exists(resource_id)
+    if not resource_exists:
+        raise HTTPException(
+            status_code=404, detail="Resource not found, may require computation."
+        )
+
     link = DataMartResourceLink(
         link=f"{API_URL}/v0/land/tree_cover_loss_by_driver/{resource_id}"
     )
@@ -188,6 +193,13 @@ async def tree_cover_loss_by_driver_post(
         dataset_version,
     )
 
+    resource_exists = await _check_resource_exists(resource_id)
+    if resource_exists:
+        raise HTTPException(
+            status_code=409,
+            detail=f"Resource f{resource_id} already exists with those parameters.",
+        )
+
     await _save_pending_resource(resource_id, request.url.path, api_key)
 
     background_tasks.add_task(
@@ -218,6 +230,14 @@ async def _get_resource(resource_id):
         raise HTTPException(
             status_code=404, detail="Resource not found, may require computation."
         )
+
+
+async def _check_resource_exists(resource_id) -> bool:
+    try:
+        await datamart_crud.get_result(resource_id)
+        return True
+    except RecordNotFoundError:
+        return False
 
 
 async def _save_pending_resource(resource_id, endpoint, api_key):

--- a/tests_v2/unit/app/routes/datamart/test_land.py
+++ b/tests_v2/unit/app/routes/datamart/test_land.py
@@ -26,7 +26,7 @@ async def test_get_tree_cover_loss_by_drivers_not_found(
     async_client: AsyncClient,
 ):
     with patch(
-        "app.routes.datamart.land._get_resource", side_effect=HTTPException(404)
+        "app.routes.datamart.land._check_resource_exists", return_value=False
     ) as mock_get_resources:
         api_key, payload = apikey
         origin = payload["domains"][0]
@@ -58,7 +58,7 @@ async def test_get_tree_cover_loss_by_drivers_found(
     async_client: AsyncClient,
 ):
     with patch(
-        "app.routes.datamart.land._get_resource", return_value=None
+        "app.routes.datamart.land._check_resource_exists", return_value=True
     ) as mock_get_resources:
         api_key, payload = apikey
         origin = payload["domains"][0]
@@ -94,7 +94,7 @@ async def test_get_tree_cover_loss_by_drivers_with_overrides(
 ):
     with (
         patch(
-            "app.routes.datamart.land._get_resource", return_value=None
+            "app.routes.datamart.land._check_resource_exists", return_value=True
         ) as mock_get_resources,
         patch(
             "app.routes.datamart.land._get_resource_id", side_effect=_get_resource_id
@@ -227,6 +227,33 @@ async def test_post_tree_cover_loss_by_drivers(
             30,
             DEFAULT_LAND_DATASET_VERSIONS | {"umd_tree_cover_loss": "v1.8"},
         )
+
+
+@pytest.mark.asyncio
+async def test_post_tree_cover_loss_by_drivers_conflict(
+    geostore,
+    apikey,
+    async_client: AsyncClient,
+):
+    api_key, payload = apikey
+    origin = payload["domains"][0]
+
+    headers = {"origin": origin, "x-api-key": api_key}
+    payload = {
+        "aoi": {
+            "type": "geostore",
+            "geostore_id": geostore,
+        },
+        "canopy_cover": 30,
+        "dataset_version": {"umd_tree_cover_loss": "v1.8"},
+    }
+
+    with patch("app.routes.datamart.land._check_resource_exists", return_value=True):
+        response = await async_client.post(
+            "/v0/land/tree_cover_loss_by_driver", headers=headers, json=payload
+        )
+
+        assert response.status_code == 409
 
 
 @pytest.mark.asyncio
@@ -451,7 +478,7 @@ class TestAdminAreaOfInterest:
     ):
         with (
             patch(
-                "app.routes.datamart.land._get_resource", return_value=None
+                "app.routes.datamart.land._check_resource_exists", return_value=True
             ) as mock_get_resources,
             patch(
                 "app.models.pydantic.datamart.get_gadm_geostore_id",


### PR DESCRIPTION
Fixes for two issues I found while testing in staging that return internal server errors.
- Using admin aoi causes an exception on `return UUID(geostore_id)` in `AdminAreaOfInterest` because `geostore_id` is already a UUID. I think this is correct, it's defined in our DB as UUID so it gets automatically converted to a UUID in Python. Wasn't quite sure how to add that to the tests though, because best I could do was fake a UUID response from DB, which doesn't tell us much.
- If you POST on an existing resource, it's just straight to the CRUD function and give a unique violation exception. I added a check for the resource first, and return a 409 Conflict if it exists. Alternatively, we could return a 200 OK with a link to the resource, thoughts?
- Refactored to _check_resource_exists function to make a bit more readable.