### PR TITLE
Add DataMart docs to openapi, and clearly mark as beta

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -242,7 +242,7 @@ def custom_openapi():
         {"name": "Task API", "tags": ["Tasks"]},
         {"name": "Analysis API", "tags": ["Analysis"]},
         {"name": "Health API", "tags": ["Health"]},
-        {"name": "Land API", "tags": ["Beta Land"]},
+        {"name": "Beta Land API", "tags": ["Beta Land"]},
     ]
 
     app.openapi_schema = openapi_schema

--- a/app/main.py
+++ b/app/main.py
@@ -216,6 +216,7 @@ tags_metadata = [
     {"name": "Analysis", "description": analysis.__doc__},
     {"name": "Job", "description": job.__doc__},
     {"name": "Health", "description": health.__doc__},
+    {"name": "Land", "description": land.__doc__},
 ]
 
 
@@ -241,6 +242,7 @@ def custom_openapi():
         {"name": "Task API", "tags": ["Tasks"]},
         {"name": "Analysis API", "tags": ["Analysis"]},
         {"name": "Health API", "tags": ["Health"]},
+        {"name": "Land API", "tags": ["Beta Land"]},
     ]
 
     app.openapi_schema = openapi_schema

--- a/app/routes/datamart/land.py
+++ b/app/routes/datamart/land.py
@@ -1,4 +1,5 @@
-"""Run analysis on registered datasets."""
+"""Beta APIs to more easily access important land use/land cover data without
+needing to directly query our low-level data management APIs."""
 
 import re
 import uuid
@@ -99,7 +100,7 @@ def _parse_area_of_interest(request: Request) -> AreaOfInterest:
     "/tree_cover_loss_by_driver",
     response_class=ORJSONResponse,
     response_model=DataMartResourceLinkResponse,
-    tags=["Land"],
+    tags=["Beta Land"],
     status_code=200,
     openapi_extra=OPENAPI_EXTRA,
 )
@@ -133,7 +134,7 @@ async def tree_cover_loss_by_driver_search(
     "/tree_cover_loss_by_driver/{resource_id}",
     response_class=ORJSONResponse,
     response_model=TreeCoverLossByDriverResponse,
-    tags=["Land"],
+    tags=["Beta Land"],
     status_code=200,
 )
 async def tree_cover_loss_by_driver_get(
@@ -159,7 +160,7 @@ async def tree_cover_loss_by_driver_get(
     "/tree_cover_loss_by_driver",
     response_class=ORJSONResponse,
     response_model=DataMartResourceLinkResponse,
-    tags=["Land"],
+    tags=["Beta Land"],
     status_code=202,
 )
 async def tree_cover_loss_by_driver_post(


### PR DESCRIPTION
Providing this so the frontend can quickly can get up-to-date docs on the request/response structures and use swagger to form docs.