### PR TITLE
GTC-3248: Fix: Do Not Create `id` and `hash` for Simplified Admin Geostores

### DIFF
--- a/app/crud/geostore.py
+++ b/app/crud/geostore.py
@@ -409,15 +409,15 @@ async def admin_params_to_dataset_version(
 
 
 async def form_admin_geostore(
-    adm_level: int,
-    bbox: List[float],
-    area: float,
-    geostore_id: str,
-    level_id: str,
-    simplify: Optional[float],
-    admin_version: str,
-    geojson: Dict,
-    name: str,
+        adm_level: int,
+        bbox: List[float],
+        area: float,
+        geostore_id: str,
+        level_id: str,
+        simplify: float | None,
+        admin_version: str,
+        geojson: Dict,
+        name: str,
 ) -> AdminGeostore:
     info = Adm0BoundaryInfo.parse_obj(
         {
@@ -428,6 +428,7 @@ async def form_admin_geostore(
             "iso": extract_level_id(0, level_id),
         }
     )
+
     if adm_level >= 1:
         info = Adm1BoundaryInfo(
             **info.dict(),
@@ -439,28 +440,35 @@ async def form_admin_geostore(
             id2=int(extract_level_id(2, level_id)),
         )
 
-    return AdminGeostore.parse_obj(
-        {
-            "type": "geoStore",
-            "id": geostore_id,
-            "attributes": {
-                "geojson": {
-                    "crs": {},
-                    "type": "FeatureCollection",
-                    "features": [
-                        {
-                            "geometry": geojson,
-                            "properties": None,
-                            "type": "Feature",
-                        }
-                    ],
-                },
-                "hash": geostore_id,
-                "provider": {},
-                "areaHa": area,
-                "bbox": bbox,
-                "lock": False,
-                "info": info.dict(),
-            },
-        }
-    )
+    # Prepare the base attributes
+    attributes = {
+        "geojson": {
+            "crs": {},
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "geometry": geojson,
+                    "properties": None,
+                    "type": "Feature",
+                }
+            ],
+        },
+        "provider": {},
+        "areaHa": area,
+        "bbox": bbox,
+        "lock": False,
+        "info": info.dict(),
+    }
+
+    # Prepare the base geostore data
+    geostore_data = {
+        "type": "geoStore",
+        "attributes": attributes,
+    }
+
+    # Only include id and hash if non-simplified area is requested. This is the only geostore we persist
+    if simplify is None:
+        geostore_data["id"] = geostore_id
+        attributes["hash"] = geostore_id
+
+    return AdminGeostore.parse_obj(geostore_data)

--- a/app/models/pydantic/geostore.py
+++ b/app/models/pydantic/geostore.py
@@ -108,7 +108,7 @@ class LandUseInfo(StrictBaseModel):
 
 class AdminGeostoreAttributes(StrictBaseModel):
     geojson: FeatureCollection
-    hash: str
+    hash: str | None
     provider: Dict
     areaHa: float
     bbox: List[float]
@@ -125,7 +125,7 @@ class AdminGeostoreAttributes(StrictBaseModel):
 
 class AdminGeostore(StrictBaseModel):
     type: Literal["geoStore"]
-    id: str
+    id: str | None
     attributes: AdminGeostoreAttributes
 
 


### PR DESCRIPTION
See solution reasoning in the commit message and the [ticket comments](https://gfw.atlassian.net/browse/GTC-3248?focusedCommentId=39571)

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [x] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

## Pull request type

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: GTC-3248


## What is the new behavior?
- simplified admin geostores do not have an `id` or `hash` property

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

