### PR TITLE
Make static vector tile caches and raster tile sets use on-demand queue

### DIFF
--- a/app/tasks/raster_tile_set_assets/utils.py
+++ b/app/tasks/raster_tile_set_assets/utils.py
@@ -7,13 +7,14 @@ from fastapi.encoders import jsonable_encoder
 from app.models.enum.assets import AssetType
 from app.models.enum.pixetl import ResamplingMethod
 from app.models.pydantic.creation_options import PixETLCreationOptions
-from app.models.pydantic.jobs import GDALDEMJob, Job, PixETLJob, GDAL2TilesJob
+from app.models.pydantic.jobs import GDAL2TilesJob, GDALDEMJob, Job, PixETLJob
 from app.settings.globals import (
     AWS_GCS_KEY_SECRET_ARN,
     DEFAULT_JOB_DURATION,
     ENV,
     MAX_CORES,
     MAX_MEM,
+    PIXETL_JOB_QUEUE,
     S3_ENTRYPOINT_URL,
 )
 from app.tasks import Callback, reader_secrets
@@ -43,6 +44,7 @@ async def create_pixetl_job(
     job_name: str,
     callback: Callback,
     parents: Optional[List[Job]] = None,
+    job_queue=PIXETL_JOB_QUEUE,
 ) -> Job:
     """Create a Batch job to process a raster tile set using pixetl."""
     co_copy = co.dict(exclude_none=True, by_alias=True)
@@ -87,6 +89,7 @@ async def create_pixetl_job(
     return PixETLJob(
         dataset=dataset,
         job_name=job_name,
+        job_queue=job_queue,
         command=command,
         environment=JOB_ENV,
         callback=callback,
@@ -226,19 +229,22 @@ async def create_resample_job(
         **kwargs,
     )
 
+
 async def create_unify_projection_job(
     dataset: str,
     old_source_uris: List[str],
     target_prefix: str,
     target_crs: str,
     job_name: str,
-    callback: Callback
+    callback: Callback,
 ) -> GDAL2TilesJob:
     """Creates a Batch job that takes all files indicated in old_source_uris
     and re-projects each to a common CRS, then places them in a mirror of the
     original directory structure under the target_prefix, divided by source
-    number. More specifically, the files from the first source URI will be
-    put at <target_prefix>/SRC_0, the files from the second under
+    number.
+
+    More specifically, the files from the first source URI will be put
+    at <target_prefix>/SRC_0, the files from the second under
     <target_prefix>/SRC_1, and so on.
     """
 

--- a/app/tasks/static_vector_tile_cache_assets.py
+++ b/app/tasks/static_vector_tile_cache_assets.py
@@ -130,6 +130,7 @@ async def static_vector_tile_cache_asset(
     create_vector_tile_cache = TileCacheJob(
         dataset=dataset,
         job_name="create_vector_tile_cache",
+        job_queue=ON_DEMAND_COMPUTE_JOB_QUEUE,
         command=command,
         parents=[export_ndjson.job_name],
         environment=report_vars,


### PR DESCRIPTION
To keep it safer, just starting with switching to on-demand the jobs we're currently being blocked by, since it does involve touching code in a quite few places to switch the queue. It looks like pre-commit also had a few things to say about these files, sorry for the mix of style updates. 