### PR TITLE
Use on demand for all raster processing jobs

### DIFF
--- a/app/models/pydantic/jobs.py
+++ b/app/models/pydantic/jobs.py
@@ -4,19 +4,16 @@ from pydantic import validator
 
 from ...settings.globals import (
     AURORA_JOB_QUEUE,
-    ON_DEMAND_COMPUTE_JOB_QUEUE,
-    DATA_LAKE_JOB_QUEUE,
     DEFAULT_JOB_DURATION,
     GDAL_PYTHON_JOB_DEFINITION,
     MAX_CORES,
     MAX_MEM,
+    ON_DEMAND_COMPUTE_JOB_QUEUE,
     PIXETL_CORES,
     PIXETL_JOB_DEFINITION,
-    PIXETL_JOB_QUEUE,
     PIXETL_MAX_MEM,
     POSTGRESQL_CLIENT_JOB_DEFINITION,
     TILE_CACHE_JOB_DEFINITION,
-    TILE_CACHE_JOB_QUEUE,
 )
 from .base import StrictBaseModel
 
@@ -106,7 +103,7 @@ class GdalPythonExportJob(Job):
     """Use for export operations from PostgreSQL to S3 data lake which require
     GDAL/ Ogr2Ogr drivers."""
 
-    job_queue = DATA_LAKE_JOB_QUEUE
+    job_queue = ON_DEMAND_COMPUTE_JOB_QUEUE
     job_definition = GDAL_PYTHON_JOB_DEFINITION
     vcpus = 1
     memory = 15000
@@ -117,7 +114,7 @@ class GdalPythonExportJob(Job):
 class TileCacheJob(Job):
     """Use for generating Vector Tile Cache using TippeCanoe."""
 
-    job_queue = TILE_CACHE_JOB_QUEUE
+    job_queue = ON_DEMAND_COMPUTE_JOB_QUEUE
     job_definition = TILE_CACHE_JOB_DEFINITION
     vcpus = max(int(MAX_CORES / 2), 1)
     num_processes = max(int(MAX_CORES / 3), 1)
@@ -129,7 +126,7 @@ class TileCacheJob(Job):
 class PixETLJob(Job):
     """Use for raster transformations using PixETL."""
 
-    job_queue = PIXETL_JOB_QUEUE
+    job_queue = ON_DEMAND_COMPUTE_JOB_QUEUE
     job_definition = PIXETL_JOB_DEFINITION
     vcpus = MAX_CORES
     memory = MAX_MEM
@@ -139,7 +136,8 @@ class PixETLJob(Job):
 
 
 class GDALCOGJob(Job):
-    """Use for creating COG files using GDAL Python docker in on-demand compute queue."""
+    """Use for creating COG files using GDAL Python docker in on-demand compute
+    queue."""
 
     job_queue = ON_DEMAND_COMPUTE_JOB_QUEUE
     job_definition = GDAL_PYTHON_JOB_DEFINITION
@@ -153,7 +151,7 @@ class GDALCOGJob(Job):
 class GDALDEMJob(Job):
     """Use for applying color maps to raster tiles with gdaldem."""
 
-    job_queue = PIXETL_JOB_QUEUE
+    job_queue = ON_DEMAND_COMPUTE_JOB_QUEUE
     job_definition = PIXETL_JOB_DEFINITION
     vcpus = PIXETL_CORES
     memory = PIXETL_MAX_MEM
@@ -165,7 +163,7 @@ class GDALDEMJob(Job):
 class GDAL2TilesJob(Job):
     """Use for generating a raster tile cache from web-mercator tiles."""
 
-    job_queue = DATA_LAKE_JOB_QUEUE
+    job_queue = ON_DEMAND_COMPUTE_JOB_QUEUE
     job_definition = GDAL_PYTHON_JOB_DEFINITION
     vcpus = MAX_CORES
     memory = MAX_MEM


### PR DESCRIPTION
Spot instances have just become completely unusable for data processing now. Pretty much all our failures are from too many spot instance recalls. Now I'm seeing a `CAPACITY:INSUFFICIENT_INSTANCE_CAPACITY` issue that's just causing jobs to get stuck forever in Runnable, and this is causing conflicts once datapump jobs retrigger after a day and try to sync the same versions.

As discussed, let's switch all raster processing jobs to on demand for reliability and assess at the end of the month if this actually even increases our costs.