### PR TITLE
GTC-3263: Add Geostore ID and Hash back to Simplified AdminGeostores

### DIFF
--- a/app/crud/geostore.py
+++ b/app/crud/geostore.py
@@ -409,15 +409,15 @@ async def admin_params_to_dataset_version(
 
 
 async def form_admin_geostore(
-        adm_level: int,
-        bbox: List[float],
-        area: float,
-        geostore_id: str,
-        level_id: str,
-        simplify: float | None,
-        admin_version: str,
-        geojson: Dict,
-        name: str,
+    adm_level: int,
+    bbox: List[float],
+    area: float,
+    geostore_id: str,
+    level_id: str,
+    simplify: Optional[float],
+    admin_version: str,
+    geojson: Dict,
+    name: str,
 ) -> AdminGeostore:
     info = Adm0BoundaryInfo.parse_obj(
         {
@@ -428,7 +428,6 @@ async def form_admin_geostore(
             "iso": extract_level_id(0, level_id),
         }
     )
-
     if adm_level >= 1:
         info = Adm1BoundaryInfo(
             **info.dict(),
@@ -440,35 +439,28 @@ async def form_admin_geostore(
             id2=int(extract_level_id(2, level_id)),
         )
 
-    # Prepare the base attributes
-    attributes = {
-        "geojson": {
-            "crs": {},
-            "type": "FeatureCollection",
-            "features": [
-                {
-                    "geometry": geojson,
-                    "properties": None,
-                    "type": "Feature",
-                }
-            ],
-        },
-        "provider": {},
-        "areaHa": area,
-        "bbox": bbox,
-        "lock": False,
-        "info": info.dict(),
-    }
-
-    # Prepare the base geostore data
-    geostore_data = {
-        "type": "geoStore",
-        "attributes": attributes,
-    }
-
-    # Only include id and hash if non-simplified area is requested. This is the only geostore we persist
-    if simplify is None:
-        geostore_data["id"] = geostore_id
-        attributes["hash"] = geostore_id
-
-    return AdminGeostore.parse_obj(geostore_data)
+    return AdminGeostore.parse_obj(
+        {
+            "type": "geoStore",
+            "id": geostore_id,
+            "attributes": {
+                "geojson": {
+                    "crs": {},
+                    "type": "FeatureCollection",
+                    "features": [
+                        {
+                            "geometry": geojson,
+                            "properties": None,
+                            "type": "Feature",
+                        }
+                    ],
+                },
+                "hash": geostore_id,
+                "provider": {},
+                "areaHa": area,
+                "bbox": bbox,
+                "lock": False,
+                "info": info.dict(),
+            },
+        }
+    )

--- a/app/models/pydantic/geostore.py
+++ b/app/models/pydantic/geostore.py
@@ -108,7 +108,7 @@ class LandUseInfo(StrictBaseModel):
 
 class AdminGeostoreAttributes(StrictBaseModel):
     geojson: FeatureCollection
-    hash: str | None
+    hash: str
     provider: Dict
     areaHa: float
     bbox: List[float]
@@ -125,7 +125,7 @@ class AdminGeostoreAttributes(StrictBaseModel):
 
 class AdminGeostore(StrictBaseModel):
     type: Literal["geoStore"]
-    id: str | None
+    id: str
     attributes: AdminGeostoreAttributes
 
 


### PR DESCRIPTION
This reverts commit 105be42c26c45ee563a9d5e6fc21f6215154b873.

In the Flagship context, we found that geostores without an ID/Hash would cause the LayerManger to fail when adding the simplified geostore geometry to the map. The LayerManager needs a unique ID to track the geometry when rendering.

Therefore, we're adding it back. This type of ID/Hash is a UUID (hexadecimal number with hyphens) and is known to fail validation in the RW Areas Microservice. This bug was the original reason for eliminating the ID from simplified geostores.

To resolve the RW Areas issue, we'll set the gestore property to `null` if an incoming Area to save is an admin area.
See [GTC-3262](https://gfw.atlassian.net/browse/GTC-3262)

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [x] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

## Pull request type
Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
4.1 Admin geostores cause Flagship map rendering to fail because there is no ID to assign to the geometry when preparing to render.

Issue Number: [GTC-3263](https://gfw.atlassian.net/browse/GTC-3263)


## What is the new behavior?
- ID/Hash values will resume being added to an AdminGeostore representation. This will cause rendering in Flagship to succeed but saving new Areas to the RW Areas Microservice will fail.

## Does this introduce a breaking change?
- [ ] Yes
- [x] No, because it's only being used by the Flagship GADM 4.1 feature branch


[GTC-3262]: https://gfw.atlassian.net/browse/GTC-3262?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GTC-3263]: https://gfw.atlassian.net/browse/GTC-3263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ