### PR TITLE
Allow simplify download AOI

### DIFF
--- a/app/settings/globals.py
+++ b/app/settings/globals.py
@@ -207,7 +207,7 @@ per_env_admin_boundary_versions: Dict[str, Dict[str, Dict[str, str]]] = {
     },
     "production": {
         "GADM": {
-            "4.1": "v4.1.75",
+            "4.1": "v4.1.85",
         }
     },
 }


### PR DESCRIPTION
- Pass simplification to download by AOI
- Create geostore differently by AOI type to support unique parameters 
- Refactor to common method across CSV and JSON endpoints
- Make CSV endpoint use CSV extension filename by default
- Update GADM dataset version for prod
- Update tests to catch missed cases