### PR TITLE
Merge-up removal of workaround for Ghana bug in GADM 4.1

### DIFF
--- a/app/settings/globals.py
+++ b/app/settings/globals.py
@@ -202,7 +202,7 @@ per_env_admin_boundary_versions: Dict[str, Dict[str, Dict[str, str]]] = {
     },
     "staging": {
         "GADM": {
-            "4.1": "v4.1.64",
+            "4.1": "v4.1.85",
         }
     },
     "production": {

--- a/app/utils/gadm.py
+++ b/app/utils/gadm.py
@@ -11,7 +11,8 @@ def extract_level_id(adm_level: int, id_string: str):
     """Given a desired admin level and a string containing at least that level
     of id, return the id of just that level."""
 
-    # Exception because of bad formatting of GHA gids in gadm_administrative_boundaries/v4.1
+    # Exception because of bad formatting of GHA gids in v4.1
+    # (corrected by us in gadm_administrative_boundaries/v4.1.85 and higher)
     if id_string.startswith("GHA") and not id_string.startswith("GHA."):
         id_string = "GHA." + id_string[3:]
     # Exception because bad ids IDN.35.4, IDN.35.8, IDN.35.9, IDN.35.13, IDN.35.14
@@ -29,9 +30,7 @@ def fix_id_pattern(adm_level: int, id_pattern_string: str, provider: str, versio
     new_pattern: str = id_pattern_string
 
     if provider == "gadm" and version == "4.1":
-        if adm_level in (1, 2) and id_pattern_string.startswith("GHA."):
-            new_pattern = new_pattern.replace("GHA.", "GHA")
-        elif id_pattern_string.rstrip(r"\__") in GADM_41_IDS_MISSING_REVISION:
+        if id_pattern_string.rstrip(r"\__") in GADM_41_IDS_MISSING_REVISION:
             new_pattern = new_pattern.rstrip(r"\__")
 
     return new_pattern

--- a/tests_v2/unit/app/utils/test_gadm.py
+++ b/tests_v2/unit/app/utils/test_gadm.py
@@ -1,6 +1,10 @@
 import pytest
 
-from app.utils.gadm import extract_level_id
+from app.utils.gadm import (
+    GADM_41_IDS_MISSING_REVISION,
+    extract_level_id,
+    fix_id_pattern,
+)
 
 
 @pytest.mark.asyncio
@@ -22,3 +26,52 @@ async def test_extract_level_gid() -> None:
     assert extract_level_id(0, match3) == "IDN"
     assert extract_level_id(1, match3) == "35"
     assert extract_level_id(2, match3) == "4"
+
+
+@pytest.mark.asyncio
+async def test_GADM_ids_are_unchanged_if_they_are_NOT_4_1() -> None:
+    orig_pattern = r"USA.5.10\__"
+    assert fix_id_pattern(2, orig_pattern, "gadm", "3.9") == orig_pattern
+
+
+@pytest.mark.asyncio
+async def test_GADM_ids_are_unchanged_if_they_are_NOT_problematic() -> None:
+    orig_id = "USA.5.10"
+    assert orig_id not in GADM_41_IDS_MISSING_REVISION
+
+    orig_pattern = orig_id + r"\__"
+    assert fix_id_pattern(2, orig_pattern, "gadm", "4.1") == orig_pattern
+
+
+@pytest.mark.asyncio
+async def test_strip_revision_sql_for_those_missing_revision() -> None:
+    for problem_gid in GADM_41_IDS_MISSING_REVISION:
+        pattern = problem_gid + r"\__"
+        assert fix_id_pattern(2, pattern, "gadm", "4.1") == problem_gid
+
+
+# In the official GADM 4.1 files some Ghana GIDs were missing a "." between "GHA"
+# and the region IDs (so what should have been "GHA.2.1_1" was "GHA2.1_1". We had
+# instituted a workaround in the Data API for this, but later decided to fix the
+# IDs by pre-processing the GADM file. These next three tests are to verify that
+# the new, fixed, IDs are dealt with correctly.
+@pytest.mark.asyncio
+async def test_GHA_GID_0_is_NOT_changed_now_that_we_have_mitigated_at_source() -> None:
+    orig_pattern = "GHA"
+    assert fix_id_pattern(0, orig_pattern, "gadm", "4.1") == orig_pattern
+
+
+@pytest.mark.asyncio
+async def test_GHA_GID_1s_are_NOT_changed_now_that_we_have_mitigated_at_source() -> (
+    None
+):
+    orig_pattern = r"GHA.4\__"
+    assert fix_id_pattern(1, orig_pattern, "gadm", "4.1") == orig_pattern
+
+
+@pytest.mark.asyncio
+async def test_GHA_GID_2s_are_NOT_changed_now_that_we_have_mitigated_at_source() -> (
+    None
+):
+    orig_pattern = r"GHA.4.1\__"
+    assert fix_id_pattern(2, orig_pattern, "gadm", "4.1") == orig_pattern


### PR DESCRIPTION
Minimal change (mostly tests) that fixes the inability to look-up Ghana sub-features via the geostore admin endpoint.