### PR TITLE
Gtc 3268/wdpa aoi dm

### DIFF
--- a/app/crud/geostore.py
+++ b/app/crud/geostore.py
@@ -278,6 +278,27 @@ async def build_gadm_geostore(
     )
 
 
+async def get_wdpa_geostore_id(dataset, version, wdpa_id):
+    src_table: Table = db.table(version)
+    src_table.schema = dataset
+    columns_etc: List[Column | Label] = [
+        db.column("gfw_geostore_id"),
+    ]
+
+    sql: Select = (
+        db.select(columns_etc)
+        .select_from(src_table)
+        .where(db.text("wdpaid=:wdpa_id").bindparams(wdpa_id=wdpa_id))
+    )
+    row = await db.first(sql)
+
+    if row is None:
+        raise RecordNotFoundError(
+            f"WDPA area with id {wdpa_id} not found in {dataset} version {version}"
+        )
+    return row.gfw_geostore_id
+
+
 async def _find_first_geostore(
     adm_level,
     admin_provider,

--- a/app/models/pydantic/datamart.py
+++ b/app/models/pydantic/datamart.py
@@ -11,7 +11,8 @@ from pydantic import Field, root_validator, validator
 
 from app.models.pydantic.responses import Response
 
-from ...crud.geostore import get_gadm_geostore_id
+from ...crud.geostore import get_gadm_geostore_id, get_wdpa_geostore_id
+from ...crud.versions import get_latest_version
 from .base import StrictBaseModel
 
 
@@ -78,6 +79,16 @@ class AdminAreaOfInterest(AreaOfInterest):
         return v or "4.1"
 
 
+class WdpaAreaOfInterest(AreaOfInterest):
+    type: Literal["protected_area"] = "protected_area"
+    wdpa_id: int = Field(..., title="World Database on Protected Areas (WDPA) ID")
+
+    async def get_geostore_id(self) -> UUID:
+        dataset = "wdpa_protected_areas"
+        latest_version = get_latest_version(dataset)
+        return await get_wdpa_geostore_id(dataset, latest_version, self.wdpa_id)
+
+
 class Global(AreaOfInterest):
     type: Literal["global"] = Field(
         "global",
@@ -97,7 +108,7 @@ class DataMartSource(StrictBaseModel):
 
 
 class DataMartMetadata(StrictBaseModel):
-    aoi: Union[GeostoreAreaOfInterest, AdminAreaOfInterest, Global]
+    aoi: Union[GeostoreAreaOfInterest, AdminAreaOfInterest, Global, WdpaAreaOfInterest]
     sources: list[DataMartSource]
 
 
@@ -119,9 +130,9 @@ class DataMartResourceLinkResponse(Response):
 
 
 class TreeCoverLossByDriverIn(StrictBaseModel):
-    aoi: Union[GeostoreAreaOfInterest, AdminAreaOfInterest, Global] = Field(
-        ..., discriminator="type"
-    )
+    aoi: Union[
+        GeostoreAreaOfInterest, AdminAreaOfInterest, Global, WdpaAreaOfInterest
+    ] = Field(..., discriminator="type")
     canopy_cover: int = 30
     dataset_version: Dict[str, str] = {}
 
@@ -233,6 +244,9 @@ def parse_area_of_interest(request: Request) -> AreaOfInterest:
 
         if aoi_type == "global":
             return Global()
+
+        if aoi_type == "protected_area":
+            return WdpaAreaOfInterest(wdpa_id=params.get("aoi[wdpa_id]"))
 
         # If neither type is provided, raise an error
         raise HTTPException(

--- a/app/models/pydantic/datamart.py
+++ b/app/models/pydantic/datamart.py
@@ -81,7 +81,7 @@ class AdminAreaOfInterest(AreaOfInterest):
 
 class WdpaAreaOfInterest(AreaOfInterest):
     type: Literal["protected_area"] = "protected_area"
-    wdpa_id: int = Field(..., title="World Database on Protected Areas (WDPA) ID")
+    wdpa_id: str = Field(..., title="World Database on Protected Areas (WDPA) ID")
 
     async def get_geostore_id(self) -> UUID:
         dataset = "wdpa_protected_areas"

--- a/tests_v2/unit/app/routes/datamart/test_land.py
+++ b/tests_v2/unit/app/routes/datamart/test_land.py
@@ -708,3 +708,100 @@ class TestGlobal:
                 assert False
 
             mock_get_resources.assert_awaited_with(resource_id)
+
+
+class TestWdpaAreaOfInterest:
+    @pytest.mark.asyncio
+    async def test_get_tree_cover_loss_by_drivers_found(
+        self,
+        apikey,
+        async_client: AsyncClient,
+    ):
+        with (
+            patch(
+                "app.routes.datamart.land._check_resource_exists", return_value=True
+            ) as mock_get_resources,
+        ):
+            api_key, payload = apikey
+            origin = payload["domains"][0]
+
+            headers = {"origin": origin}
+            params = {
+                "x-api-key": api_key,
+                "aoi[type]": "protected_area",
+                "canopy_cover": 30,
+                "aoi[wdpa_id]": 123,
+            }
+            aoi = {"type": "protected_area", "wdpa_id": 123}
+            resource_id = _get_resource_id(
+                "tree_cover_loss_by_driver", aoi, 30, DEFAULT_LAND_DATASET_VERSIONS
+            )
+
+            response = await async_client.get(
+                "/v0/land/tree_cover_loss_by_driver", headers=headers, params=params
+            )
+
+            assert response.status_code == 200
+            assert (
+                f"/v0/land/tree_cover_loss_by_driver/{resource_id}"
+                in response.json()["data"]["link"]
+            )
+            mock_get_resources.assert_awaited_with(resource_id)
+
+    @pytest.mark.asyncio
+    async def test_post_tree_cover_loss_by_drivers(
+        self,
+        geostore,
+        apikey,
+        async_client: AsyncClient,
+    ):
+        api_key, payload = apikey
+        origin = payload["domains"][0]
+
+        headers = {"origin": origin, "x-api-key": api_key}
+        dataset_version = {"umd_tree_cover_loss": "v1.8"}
+        aoi = {"type": "protected_area", "wdpa_id": 123}
+        payload = {
+            "aoi": aoi,
+            "canopy_cover": 30,
+            "dataset_version": dataset_version,
+        }
+        with (
+            patch(
+                "app.routes.datamart.land._check_resource_exists", return_value=False
+            ) as mock_get_resources,
+            patch(
+                "app.models.pydantic.datamart.get_wdpa_geostore_id",
+                return_value=geostore,
+            ),
+        ):
+            dataset_versions = DEFAULT_LAND_DATASET_VERSIONS | dataset_version
+            resource_id = _get_resource_id(
+                "tree_cover_loss_by_driver",
+                aoi,
+                30,
+                dataset_versions,
+            )
+
+            response = await async_client.post(
+                "/v0/land/tree_cover_loss_by_driver", headers=headers, json=payload
+            )
+
+            assert response.status_code == 202
+
+            body = response.json()
+
+            assert body["status"] == "success"
+            assert (
+                f"/v0/land/tree_cover_loss_by_driver/{resource_id}"
+                in body["data"]["link"]
+            )
+
+            resource_id = body["data"]["link"].split("/")[-1]
+            try:
+                resource_id = uuid.UUID(resource_id)
+                assert True
+            except ValueError:
+                assert False
+
+            mock_get_resources.assert_awaited_with(resource_id)

--- a/tests_v2/unit/app/routes/datamart/test_land.py
+++ b/tests_v2/unit/app/routes/datamart/test_land.py
@@ -730,9 +730,9 @@ class TestWdpaAreaOfInterest:
                 "x-api-key": api_key,
                 "aoi[type]": "protected_area",
                 "canopy_cover": 30,
-                "aoi[wdpa_id]": 123,
+                "aoi[wdpa_id]": "123",
             }
-            aoi = {"type": "protected_area", "wdpa_id": 123}
+            aoi = {"type": "protected_area", "wdpa_id": "123"}
             resource_id = _get_resource_id(
                 "tree_cover_loss_by_driver", aoi, 30, DEFAULT_LAND_DATASET_VERSIONS
             )
@@ -760,7 +760,7 @@ class TestWdpaAreaOfInterest:
 
         headers = {"origin": origin, "x-api-key": api_key}
         dataset_version = {"umd_tree_cover_loss": "v1.8"}
-        aoi = {"type": "protected_area", "wdpa_id": 123}
+        aoi = {"type": "protected_area", "wdpa_id": "123"}
         payload = {
             "aoi": aoi,
             "canopy_cover": 30,


### PR DESCRIPTION
Enable TCL drivers datamart query using wdpa AOI. This way users don't have to do the extra work of fetching the geostore_id to run a query