### PR TITLE
GTC-3141: Delete Failed Analysis Resources

### DIFF
--- a/app/crud/datamart.py
+++ b/app/crud/datamart.py
@@ -30,3 +30,10 @@ async def update_result(result_id: uuid.UUID, result_data) -> AnalysisResult:
     await analysis_result.update(**json.loads(result_data.json(by_alias=False))).apply()
 
     return analysis_result
+
+
+async def delete_result(result_id: uuid.UUID) -> AnalysisResult:
+    analysis_result: AnalysisResult = await get_result(result_id)
+    await AnalysisResult.delete.where(AnalysisResult.id == result_id).gino.status()
+
+    return analysis_result

--- a/app/routes/datamart/land.py
+++ b/app/routes/datamart/land.py
@@ -156,15 +156,26 @@ async def tree_cover_loss_by_driver_get(
     response_class=ORJSONResponse,
     status_code=204,
     tags=["Beta Land"],
+    summary="Delete **failed** tree cover loass by driver analysis resource",
+    description="""
+      ## Delete Tree Cover Loss by Driver Analysis
+      **Only resources in 'failed' status can be removed.**
+      This operation permanently deletes the resource record.
+    """,
     responses={
-        204: {"description": "Resource successfully deleted"},
-        400: {"description": "Resource cannot be deleted because it's not in 'failed' status"},
-        404: {"description": "Resource not found"},
+        204: {"description": "Analysis resource successfully deleted"},
+        400: {"description": "Analysis resource cannot be deleted because it's not in 'failed' status"},
+        404: {"description": "Analysis resource not found"},
     },
 )
 async def tree_cover_loss_by_driver_delete(
         *,
-        resource_id: UUID = Path(..., title="Tree cover loss by driver ID"),
+        resource_id: UUID = Path(
+            ...,
+            title="Tree cover loss by driver analysis resource ID",
+            description="UUID of the **failed** analysis resource to delete",
+            example="123e4567-e89b-12d3-a456-426614174000"
+        ),
         api_key: APIKey = Depends(get_api_key),
 ):
     """Delete a tree cover loss by drivers resource.
@@ -182,6 +193,7 @@ async def tree_cover_loss_by_driver_delete(
     await _delete_resource(resource_id)
 
     return Response(status_code=204)
+
 
 @router.post(
     "/tree_cover_loss_by_driver",

--- a/app/routes/datamart/land.py
+++ b/app/routes/datamart/land.py
@@ -276,7 +276,7 @@ async def _get_resource(resource_id):
 
 
 async def _delete_resource(resource_id):
-    pass
+    await datamart_crud.delete_result(resource_id)
 
 
 async def _check_resource_exists(resource_id) -> bool:

--- a/app/routes/datamart/land.py
+++ b/app/routes/datamart/land.py
@@ -156,12 +156,8 @@ async def tree_cover_loss_by_driver_get(
     response_class=ORJSONResponse,
     status_code=204,
     tags=["Beta Land"],
-    summary="Delete **failed** tree cover loass by driver analysis resource",
-    description="""
-      ## Delete Tree Cover Loss by Driver Analysis
-      **Only resources in 'failed' status can be removed.**
-      This operation permanently deletes the resource record.
-    """,
+    summary="Delete Tree Cover Loss by Driver Analysis",
+    description="Only analysis resources with 'failed' status can be removed. This operation permanently deletes the resource.",
     responses={
         204: {"description": "Analysis resource successfully deleted"},
         400: {"description": "Analysis resource cannot be deleted because it's not in 'failed' status"},

--- a/app/routes/datamart/land.py
+++ b/app/routes/datamart/land.py
@@ -151,6 +151,38 @@ async def tree_cover_loss_by_driver_get(
     return tree_cover_loss_by_driver_response
 
 
+@router.delete(
+    "/tree_cover_loss_by_driver/{resource_id}",
+    response_class=ORJSONResponse,
+    status_code=204,
+    tags=["Beta Land"],
+    responses={
+        204: {"description": "Resource successfully deleted"},
+        400: {"description": "Resource cannot be deleted because it's not in 'failed' status"},
+        404: {"description": "Resource not found"},
+    },
+)
+async def tree_cover_loss_by_driver_delete(
+        *,
+        resource_id: UUID = Path(..., title="Tree cover loss by driver ID"),
+        api_key: APIKey = Depends(get_api_key),
+):
+    """Delete a tree cover loss by drivers resource.
+
+    Only resources with 'failed' status can be deleted.
+    """
+    tree_cover_loss_by_driver = await _get_resource(resource_id)
+
+    if tree_cover_loss_by_driver.status != AnalysisStatus.failed:
+        raise HTTPException(
+            status_code=400,
+            detail="Only resources with 'failed' status can be deleted"
+        )
+
+    await _delete_resource(resource_id)
+
+    return Response(status_code=204)
+
 @router.post(
     "/tree_cover_loss_by_driver",
     response_class=ORJSONResponse,
@@ -241,6 +273,10 @@ async def _get_resource(resource_id):
         raise HTTPException(
             status_code=404, detail="Resource not found, may require computation."
         )
+
+
+async def _delete_resource(resource_id):
+    pass
 
 
 async def _check_resource_exists(resource_id) -> bool:

--- a/terraform/modules/api_gateway/gateway/main.tf
+++ b/terraform/modules/api_gateway/gateway/main.tf
@@ -180,6 +180,29 @@ module "datamart_get" {
 }
 
 
+module "datamart_delete" {
+  source = "../endpoint"
+
+  rest_api_id   = aws_api_gateway_rest_api.api_gw_api.id
+  authorizer_id = aws_api_gateway_authorizer.api_key.id
+  api_resource  = module.datamart_proxy.aws_api_gateway_resource
+
+  require_api_key = true
+  http_method     = "DELETE"
+  authorization   = "CUSTOM"
+
+  integration_parameters = {
+    "integration.request.path.datamart_proxy" = "method.request.path.datamart_proxy"
+  }
+
+  method_parameters = {
+    "method.request.path.datamart_proxy" = true
+  }
+
+  integration_uri = "http://${var.lb_dns_name}/v0/land/{datamart_proxy}"
+}
+
+
 module "datamart_post" {
   source = "../endpoint"
 
@@ -285,7 +308,8 @@ resource "aws_api_gateway_deployment" "api_gw_dep" {
     module.download_shapes_endpoint["geotiff"].integration_point,
     module.unprotected_endpoints.integration_point,
     module.datamart_get.integration_point,
-    module.datamart_post.integration_point
+    module.datamart_post.integration_point,
+    module.datamart_delete.integration_point
   ]
 
   lifecycle {

--- a/tests_v2/unit/app/routes/datamart/test_land.py
+++ b/tests_v2/unit/app/routes/datamart/test_land.py
@@ -424,93 +424,6 @@ async def test_get_tree_cover_loss_by_drivers_after_create_with_retry(
         assert response.json()["data"]["status"] == "pending"
 
 
-class TestDeleteTclResource:
-    @pytest.mark.asyncio
-    async def test_delete_tree_cover_loss_by_drivers_deletes_the_failed_resource(
-            self,
-            geostore,
-            apikey,
-            async_client: AsyncClient,
-    ):
-        api_key, payload = apikey
-        origin = payload["domains"][0]
-
-        headers = {"origin": origin, "x-api-key": api_key}
-        with patch(
-                "app.routes.datamart.land.datamart_crud.get_result",
-                return_value=AnalysisResult(status=AnalysisStatus.failed),
-        ), patch(
-            "app.routes.datamart.land.datamart_crud.delete_result",
-            return_value=AnalysisResult(status=AnalysisStatus.failed)
-        ):
-            aoi = {"type": "geostore", "geostore_id": geostore}
-            resource_id = _get_resource_id(
-                "tree_cover_loss_by_driver", aoi, 30, DEFAULT_LAND_DATASET_VERSIONS
-            )
-            response = await async_client.delete(
-                f"/v0/land/tree_cover_loss_by_driver/{resource_id}", headers=headers
-            )
-
-            assert response.status_code == 204
-
-
-    @pytest.mark.asyncio
-    @pytest.mark.parametrize("status", [AnalysisStatus.pending, AnalysisStatus.saved])
-    async def test_delete_tree_cover_loss_by_drivers_fails_for_status(
-            self,
-            status,
-            geostore,
-            apikey,
-            async_client: AsyncClient,
-    ):
-        api_key, payload = apikey
-        origin = payload["domains"][0]
-
-        headers = {"origin": origin, "x-api-key": api_key}
-        with patch(
-                "app.routes.datamart.land._get_resource",
-                return_value=TreeCoverLossByDriver(status=status),
-        ):
-            aoi = {"type": "geostore", "geostore_id": geostore}
-            resource_id = _get_resource_id(
-                "tree_cover_loss_by_driver", aoi, 30, DEFAULT_LAND_DATASET_VERSIONS
-            )
-            response = await async_client.delete(
-                f"/v0/land/tree_cover_loss_by_driver/{resource_id}", headers=headers
-            )
-
-            assert response.status_code == 400
-
-
-    @pytest.mark.asyncio
-    async def test_delete_tree_cover_loss_by_drivers_fails_when_resource_doesnt_exist(
-            self,
-            geostore,
-            apikey,
-            async_client: AsyncClient,
-    ):
-
-        api_key, payload = apikey
-        origin = payload["domains"][0]
-
-        headers = {"origin": origin, "x-api-key": api_key}
-
-        # Mock the underlying CRUD operation to raise RecordNotFoundError
-        with patch(
-            "app.routes.datamart.land.datamart_crud.get_result",
-            side_effect=RecordNotFoundError("Resource not found"),
-        ):
-            aoi = {"type": "geostore", "geostore_id": geostore}
-            resource_id = _get_resource_id(
-            "tree_cover_loss_by_driver", aoi, 30, DEFAULT_LAND_DATASET_VERSIONS
-            )
-            response = await async_client.delete(
-                f"/v0/land/tree_cover_loss_by_driver/{resource_id}",
-                headers=headers
-            )
-
-            assert response.status_code == 404
-
 
 @pytest.mark.asyncio
 async def test_get_tree_cover_loss_by_drivers_after_create_saved(
@@ -651,6 +564,94 @@ async def test_compute_tree_cover_loss_by_driver_error(geostore):
                 message=MOCK_ERROR_RESOURCE["message"],
             ),
         )
+
+
+class TestDeleteTclResource:
+    @pytest.mark.asyncio
+    async def test_delete_tree_cover_loss_by_drivers_deletes_the_failed_resource(
+            self,
+            geostore,
+            apikey,
+            async_client: AsyncClient,
+    ):
+        api_key, payload = apikey
+        origin = payload["domains"][0]
+
+        headers = {"origin": origin, "x-api-key": api_key}
+        with patch(
+                "app.routes.datamart.land.datamart_crud.get_result",
+                return_value=AnalysisResult(status=AnalysisStatus.failed),
+        ), patch(
+            "app.routes.datamart.land.datamart_crud.delete_result",
+            return_value=AnalysisResult(status=AnalysisStatus.failed)
+        ):
+            aoi = {"type": "geostore", "geostore_id": geostore}
+            resource_id = _get_resource_id(
+                "tree_cover_loss_by_driver", aoi, 30, DEFAULT_LAND_DATASET_VERSIONS
+            )
+            response = await async_client.delete(
+                f"/v0/land/tree_cover_loss_by_driver/{resource_id}", headers=headers
+            )
+
+            assert response.status_code == 204
+
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("status", [AnalysisStatus.pending, AnalysisStatus.saved])
+    async def test_delete_tree_cover_loss_by_drivers_fails_for_status(
+            self,
+            status,
+            geostore,
+            apikey,
+            async_client: AsyncClient,
+    ):
+        api_key, payload = apikey
+        origin = payload["domains"][0]
+
+        headers = {"origin": origin, "x-api-key": api_key}
+        with patch(
+                "app.routes.datamart.land._get_resource",
+                return_value=TreeCoverLossByDriver(status=status),
+        ):
+            aoi = {"type": "geostore", "geostore_id": geostore}
+            resource_id = _get_resource_id(
+                "tree_cover_loss_by_driver", aoi, 30, DEFAULT_LAND_DATASET_VERSIONS
+            )
+            response = await async_client.delete(
+                f"/v0/land/tree_cover_loss_by_driver/{resource_id}", headers=headers
+            )
+
+            assert response.status_code == 400
+
+
+    @pytest.mark.asyncio
+    async def test_delete_tree_cover_loss_by_drivers_fails_when_resource_doesnt_exist(
+            self,
+            geostore,
+            apikey,
+            async_client: AsyncClient,
+    ):
+
+        api_key, payload = apikey
+        origin = payload["domains"][0]
+
+        headers = {"origin": origin, "x-api-key": api_key}
+
+        # Mock the underlying CRUD operation to raise RecordNotFoundError
+        with patch(
+                "app.routes.datamart.land.datamart_crud.get_result",
+                side_effect=RecordNotFoundError("Resource not found"),
+        ):
+            aoi = {"type": "geostore", "geostore_id": geostore}
+            resource_id = _get_resource_id(
+                "tree_cover_loss_by_driver", aoi, 30, DEFAULT_LAND_DATASET_VERSIONS
+            )
+            response = await async_client.delete(
+                f"/v0/land/tree_cover_loss_by_driver/{resource_id}",
+                headers=headers
+            )
+
+            assert response.status_code == 404
 
 
 class TestAdminAreaOfInterest:


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [x] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

## Pull request type
Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## What is the current behavior?
There is no way to delete a 'failed' analysis from the collection of resources. Therefore, once the analysis makes it to the 'failed' state, it continue to return that status and a new analysis cannot be started.

Issue Number: [GTC-3141](https://gfw.atlassian.net/browse/GTC-3186)


## What is the new behavior?
- an analysis resource can now be deleted if it's in a 'failed' state

## Does this introduce a breaking change?
- [ ] Yes
- [x] No


[GTC-3141]: https://gfw.atlassian.net/browse/GTC-3141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ