### PR TITLE
Add carbon emissions to TCL by drivers DataMart endpoint

### DIFF
--- a/app/routes/datasets/__init__.py
+++ b/app/routes/datasets/__init__.py
@@ -56,6 +56,19 @@ OPENAPI_EXTRA_AOI = {
                         "subregion": "2",
                     },
                 },
+                "Global": {
+                    "summary": "Global Extent",
+                    "description": "Full spatial extent of dataset",
+                    "value": {"type": "global"},
+                },
+                "WDPA Area Of Interest": {
+                    "summary": "WDPA Area Of Interest",
+                    "description": "World Database on Protected Areas (WDPA) Boundary",
+                    "value": {
+                        "type": "protected_area",
+                        "wdpa_id": "123",
+                    },
+                },
             },
             "description": "The Area of Interest",
             "schema": {
@@ -63,6 +76,7 @@ OPENAPI_EXTRA_AOI = {
                     {"$ref": "#/components/schemas/GeostoreAreaOfInterest"},
                     {"$ref": "#/components/schemas/AdminAreaOfInterest"},
                     {"$ref": "#/components/schemas/Global"},
+                    {"$ref": "#/components/schemas/WdpaAreaOfInterest"},
                 ]
             },
         }

--- a/app/tasks/datamart/land.py
+++ b/app/tasks/datamart/land.py
@@ -33,7 +33,7 @@ async def compute_tree_cover_loss_by_driver(
             f"Computing tree cover loss by driver for resource {resource_id} with geostore {geostore_id} and canopy cover {canopy_cover}"
         )
         geostore: GeostoreCommon = await get_geostore(geostore_id, GeostoreOrigin.rw)
-        query = f"SELECT SUM(area__ha) FROM data WHERE umd_tree_cover_density_2000__threshold >= {canopy_cover} GROUP BY umd_tree_cover_loss__year, tsc_tree_cover_loss_drivers__driver"
+        query = f"SELECT SUM(area__ha), SUM(gfw_forest_carbon_gross_emissions__Mg_CO2e) FROM data WHERE umd_tree_cover_density_2000__threshold >= {canopy_cover} GROUP BY umd_tree_cover_loss__year, tsc_tree_cover_loss_drivers__driver"
 
         results = await _query_dataset_json(
             "umd_tree_cover_loss",

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -40,7 +40,7 @@ services:
       - ON_DEMAND_COMPUTE_JOB_QUEUE=cogify_jq
       - API_URL=http://app_dev:80
       - RASTER_ANALYSIS_LAMBDA_NAME=raster-analysis-tiled_raster_analysis-default
-      - RW_API_URL=https://staging-api.resourcewatch.org
+      - RW_API_URL=https://api.resourcewatch.org
       - GOOGLE_APPLICATION_CREDENTIALS=/root/.gcs/private_key.json
       - PIXETL_CORES=4
       - MAX_CORES=4

--- a/tests_v2/unit/app/routes/datamart/test_land.py
+++ b/tests_v2/unit/app/routes/datamart/test_land.py
@@ -356,7 +356,7 @@ async def test_get_tree_cover_loss_by_drivers_as_csv(
         print(response.content)
         assert (
             response.content
-            == b'"drivers_type","loss_year","loss_area_ha"\r\n"Permanent agriculture",2001,10\r\n"Hard commodities",2001,12\r\n"Shifting cultivation",2001,7\r\n"Forest management",2001,93.4\r\n"Wildfires",2001,42\r\n"Settlements and infrastructure",2001,13.562\r\n"Other natural disturbances",2001,6\r\n"Permanent agriculture",2002,100\r\n"Hard commodities",2002,100\r\n"Shifting cultivation",2002,100\r\n"Forest management",2002,100\r\n"Wildfires",2002,100\r\n'
+            == b'"drivers_type","loss_year","loss_area_ha","gross_carbon_emissions_Mg"\r\n"Permanent agriculture",2001,10,66.5\r\n"Commodity driven deforestation",2001,12,78.9\r\n"Shifting agriculture",2001,7,54.2\r\n"Forestry",2001,93.4,101.0\r\n"Wildfire",2001,42,32.8\r\n"Urbanization",2001,13.562,25.0\r\n"Other natural disturbances",2001,6,11.5\r\n"Permanent agriculture",2002,100,80.0\r\n"Commodity driven deforestation",2002,100,91.3\r\n"Shifting agriculture",2002,100,87.0\r\n"Forestry",2002,100,95.2\r\n"Wildfire",2002,100,88.8\r\n'
         )
 
 
@@ -384,7 +384,7 @@ async def test_compute_tree_cover_loss_by_driver(geostore):
         mock_query_dataset_json.assert_awaited_once_with(
             "umd_tree_cover_loss",
             "v1.8",
-            "SELECT SUM(area__ha) FROM data WHERE umd_tree_cover_density_2000__threshold >= 30 GROUP BY umd_tree_cover_loss__year, tsc_tree_cover_loss_drivers__driver",
+            "SELECT SUM(area__ha), SUM(gfw_forest_carbon_gross_emissions__Mg_CO2e) FROM data WHERE umd_tree_cover_density_2000__threshold >= 30 GROUP BY umd_tree_cover_loss__year, tsc_tree_cover_loss_drivers__driver",
             geostore_common,
             DEFAULT_LAND_DATASET_VERSIONS | {"umd_tree_cover_loss": "v1.8"},
         )
@@ -421,7 +421,7 @@ async def test_compute_tree_cover_loss_by_driver_error(geostore):
         mock_query_dataset_json.assert_awaited_once_with(
             "umd_tree_cover_loss",
             "v1.11",
-            "SELECT SUM(area__ha) FROM data WHERE umd_tree_cover_density_2000__threshold >= 30 GROUP BY umd_tree_cover_loss__year, tsc_tree_cover_loss_drivers__driver",
+            "SELECT SUM(area__ha), SUM(gfw_forest_carbon_gross_emissions__Mg_CO2e) FROM data WHERE umd_tree_cover_density_2000__threshold >= 30 GROUP BY umd_tree_cover_loss__year, tsc_tree_cover_loss_drivers__driver",
             geostore_common,
             DEFAULT_LAND_DATASET_VERSIONS,
         )
@@ -681,61 +681,73 @@ MOCK_RESULT = [
         "umd_tree_cover_loss__year": 2001,
         "tsc_tree_cover_loss_drivers__driver": "Permanent agriculture",
         "area__ha": 10,
+        "gfw_forest_carbon_gross_emissions__Mg_CO2e": 66.5,
     },
     {
         "umd_tree_cover_loss__year": 2001,
-        "tsc_tree_cover_loss_drivers__driver": "Hard commodities",
+        "tsc_tree_cover_loss_drivers__driver": "Commodity driven deforestation",
         "area__ha": 12,
+        "gfw_forest_carbon_gross_emissions__Mg_CO2e": 78.9,
     },
     {
         "umd_tree_cover_loss__year": 2001,
-        "tsc_tree_cover_loss_drivers__driver": "Shifting cultivation",
+        "tsc_tree_cover_loss_drivers__driver": "Shifting agriculture",
         "area__ha": 7,
+        "gfw_forest_carbon_gross_emissions__Mg_CO2e": 54.2,
     },
     {
         "umd_tree_cover_loss__year": 2001,
-        "tsc_tree_cover_loss_drivers__driver": "Forest management",
+        "tsc_tree_cover_loss_drivers__driver": "Forestry",
         "area__ha": 93.4,
+        "gfw_forest_carbon_gross_emissions__Mg_CO2e": 101.0,
     },
     {
         "umd_tree_cover_loss__year": 2001,
-        "tsc_tree_cover_loss_drivers__driver": "Wildfires",
+        "tsc_tree_cover_loss_drivers__driver": "Wildfire",
         "area__ha": 42,
+        "gfw_forest_carbon_gross_emissions__Mg_CO2e": 32.8,
     },
     {
         "umd_tree_cover_loss__year": 2001,
-        "tsc_tree_cover_loss_drivers__driver": "Settlements and infrastructure",
+        "tsc_tree_cover_loss_drivers__driver": "Urbanization",
         "area__ha": 13.562,
+        "gfw_forest_carbon_gross_emissions__Mg_CO2e": 25.0,
     },
     {
         "umd_tree_cover_loss__year": 2001,
         "tsc_tree_cover_loss_drivers__driver": "Other natural disturbances",
         "area__ha": 6,
+        "gfw_forest_carbon_gross_emissions__Mg_CO2e": 11.5,
     },
     {
         "umd_tree_cover_loss__year": 2002,
         "tsc_tree_cover_loss_drivers__driver": "Permanent agriculture",
         "area__ha": 100,
+        "gfw_forest_carbon_gross_emissions__Mg_CO2e": 80.0,
     },
     {
         "umd_tree_cover_loss__year": 2002,
-        "tsc_tree_cover_loss_drivers__driver": "Hard commodities",
+        "tsc_tree_cover_loss_drivers__driver": "Commodity driven deforestation",
         "area__ha": 100,
+        "gfw_forest_carbon_gross_emissions__Mg_CO2e": 91.3,
     },
     {
         "umd_tree_cover_loss__year": 2002,
-        "tsc_tree_cover_loss_drivers__driver": "Shifting cultivation",
+        "tsc_tree_cover_loss_drivers__driver": "Shifting agriculture",
         "area__ha": 100,
+        "gfw_forest_carbon_gross_emissions__Mg_CO2e": 87.0,
     },
     {
         "umd_tree_cover_loss__year": 2002,
-        "tsc_tree_cover_loss_drivers__driver": "Forest management",
+        "tsc_tree_cover_loss_drivers__driver": "Forestry",
         "area__ha": 100,
+        "gfw_forest_carbon_gross_emissions__Mg_CO2e": 95.2,
     },
     {
         "umd_tree_cover_loss__year": 2002,
-        "tsc_tree_cover_loss_drivers__driver": "Wildfires",
+        "tsc_tree_cover_loss_drivers__driver": "Wildfire",
         "area__ha": 100,
+        "gfw_forest_carbon_gross_emissions__Mg_CO2e": 88.8,
     },
 ]
 
@@ -747,30 +759,37 @@ MOCK_RESOURCE = {
             {
                 "drivers_type": "Permanent agriculture",
                 "loss_area_ha": 110,
+                "gross_carbon_emissions_Mg": 146.5,
             },
             {
-                "drivers_type": "Hard commodities",
+                "drivers_type": "Commodity driven deforestation",
                 "loss_area_ha": 112,
+                "gross_carbon_emissions_Mg": 170.2,
             },
             {
-                "drivers_type": "Shifting cultivation",
+                "drivers_type": "Shifting agriculture",
                 "loss_area_ha": 107,
+                "gross_carbon_emissions_Mg": 141.2,
             },
             {
-                "drivers_type": "Forest management",
+                "drivers_type": "Forestry",
                 "loss_area_ha": 193.4,
+                "gross_carbon_emissions_Mg": 196.2,
             },
             {
-                "drivers_type": "Wildfires",
+                "drivers_type": "Wildfire",
                 "loss_area_ha": 142,
+                "gross_carbon_emissions_Mg": 121.6,
             },
             {
-                "drivers_type": "Settlements and infrastructure",
+                "drivers_type": "Urbanization",
                 "loss_area_ha": 13.562,
+                "gross_carbon_emissions_Mg": 25.0,
             },
             {
                 "drivers_type": "Other natural disturbances",
                 "loss_area_ha": 6,
+                "gross_carbon_emissions_Mg": 11.5,
             },
         ],
         "yearly_tree_cover_loss_by_driver": [
@@ -778,61 +797,73 @@ MOCK_RESOURCE = {
                 "drivers_type": "Permanent agriculture",
                 "loss_year": 2001,
                 "loss_area_ha": 10,
+                "gross_carbon_emissions_Mg": 66.5,
             },
             {
-                "drivers_type": "Hard commodities",
+                "drivers_type": "Commodity driven deforestation",
                 "loss_year": 2001,
                 "loss_area_ha": 12,
+                "gross_carbon_emissions_Mg": 78.9,
             },
             {
-                "drivers_type": "Shifting cultivation",
+                "drivers_type": "Shifting agriculture",
                 "loss_year": 2001,
                 "loss_area_ha": 7,
+                "gross_carbon_emissions_Mg": 54.2,
             },
             {
-                "drivers_type": "Forest management",
+                "drivers_type": "Forestry",
                 "loss_year": 2001,
                 "loss_area_ha": 93.4,
+                "gross_carbon_emissions_Mg": 101.0,
             },
             {
-                "drivers_type": "Wildfires",
+                "drivers_type": "Wildfire",
                 "loss_year": 2001,
                 "loss_area_ha": 42,
+                "gross_carbon_emissions_Mg": 32.8,
             },
             {
-                "drivers_type": "Settlements and infrastructure",
+                "drivers_type": "Urbanization",
                 "loss_year": 2001,
                 "loss_area_ha": 13.562,
+                "gross_carbon_emissions_Mg": 25.0,
             },
             {
                 "drivers_type": "Other natural disturbances",
                 "loss_year": 2001,
                 "loss_area_ha": 6,
+                "gross_carbon_emissions_Mg": 11.5,
             },
             {
                 "drivers_type": "Permanent agriculture",
                 "loss_year": 2002,
                 "loss_area_ha": 100,
+                "gross_carbon_emissions_Mg": 80.0,
             },
             {
-                "drivers_type": "Hard commodities",
+                "drivers_type": "Commodity driven deforestation",
                 "loss_year": 2002,
                 "loss_area_ha": 100,
+                "gross_carbon_emissions_Mg": 91.3,
             },
             {
-                "drivers_type": "Shifting cultivation",
+                "drivers_type": "Shifting agriculture",
                 "loss_year": 2002,
                 "loss_area_ha": 100,
+                "gross_carbon_emissions_Mg": 87.0,
             },
             {
-                "drivers_type": "Forest management",
+                "drivers_type": "Forestry",
                 "loss_year": 2002,
                 "loss_area_ha": 100,
+                "gross_carbon_emissions_Mg": 95.2,
             },
             {
-                "drivers_type": "Wildfires",
+                "drivers_type": "Wildfire",
                 "loss_year": 2002,
                 "loss_area_ha": 100,
+                "gross_carbon_emissions_Mg": 88.8,
             },
         ],
     },


### PR DESCRIPTION
Carbon emissions is now included as additional entry to the tree cover loss by drivers response as below. Not releasing a new version as it's a non-breaking additive change.  This also updates the drive names to what's in the latest version (and as a bonus adds WDPA AOI to the API docs:))

```
    "result": {
        "tree_cover_loss_by_driver": [
            {
                "drivers_type": "Permanent agriculture",
                "loss_area_ha": 110,
                "gross_carbon_emissions_Mg": 146.5,
            },
            ...
            {
                "drivers_type": "Shifting agriculture",
                "loss_area_ha": 107,
                "gross_carbon_emissions_Mg": 141.2,
            },
            {
                "drivers_type": "Forestry",
                "loss_area_ha": 193.4,
                "gross_carbon_emissions_Mg": 196.2,
            },
        ],
        "yearly_tree_cover_loss_by_driver": [
            {
                "drivers_type": "Permanent agriculture",
                "loss_year": 2001,
                "loss_area_ha": 10,
                "gross_carbon_emissions_Mg": 66.5,
            },
            ...,
            {
                "drivers_type": "Commodity driven deforestation",
                "loss_year": 2001,
                "loss_area_ha": 12,
                "gross_carbon_emissions_Mg": 78.9,
            },
            {
                "drivers_type": "Shifting agriculture",
                "loss_year": 2001,
                "loss_area_ha": 7,
                "gross_carbon_emissions_Mg": 54.2,
            },
        ],
    },
 
```