### PR TITLE
batch query and rate limit fixes

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -228,4 +228,6 @@ module "api_gateway" {
   lambda_role_policy      = data.template_file.lambda_role_policy.rendered
   cloudwatch_policy       = data.local_file.cloudwatch_log_policy.content
   lambda_invoke_policy    = data.local_file.iam_lambda_invoke.content
+  api_gateway_usage_plans = var.api_gateway_usage_plans
+  service_url             = var.service_url
 }

--- a/terraform/modules/api_gateway/gateway/main.tf
+++ b/terraform/modules/api_gateway/gateway/main.tf
@@ -33,10 +33,12 @@ resource "aws_api_gateway_resource" "query_parent" {
 }
 
 module "query_resource" {
-  source      = "../resource"
-  rest_api_id = aws_api_gateway_rest_api.api_gw_api.id
-  parent_id   = aws_api_gateway_resource.query_parent.id
-  path_part   = "{proxy+}"
+  source                  = "../resource"
+  rest_api_id             = aws_api_gateway_rest_api.api_gw_api.id
+  parent_id               = aws_api_gateway_resource.query_parent.id
+  path_part               = "{proxy+}"
+  api_gateway_usage_plans = var.api_gateway_usage_plans
+  service_url             = var.service_url
 }
 
 module "query_get" {
@@ -102,11 +104,12 @@ resource "aws_api_gateway_resource" "download_parent" {
 module "download_shapes_resources" {
   source = "../resource"
 
-  rest_api_id = aws_api_gateway_rest_api.api_gw_api.id
-  parent_id   = aws_api_gateway_resource.download_parent.id
-
-  for_each  = toset(var.download_endpoints)
-  path_part = each.key
+  rest_api_id             = aws_api_gateway_rest_api.api_gw_api.id
+  parent_id               = aws_api_gateway_resource.download_parent.id
+  api_gateway_usage_plans = var.api_gateway_usage_plans
+  service_url             = var.service_url
+  for_each                = toset(var.download_endpoints)
+  path_part               = each.key
 }
 
 module "download_shapes_endpoint" {
@@ -150,9 +153,11 @@ resource "aws_api_gateway_resource" "datamart_land" {
 module "datamart_proxy" {
   source = "../resource"
 
-  rest_api_id = aws_api_gateway_rest_api.api_gw_api.id
-  parent_id   = aws_api_gateway_resource.datamart_land.id
-  path_part   = "{datamart_proxy+}"
+  rest_api_id             = aws_api_gateway_rest_api.api_gw_api.id
+  parent_id               = aws_api_gateway_resource.datamart_land.id
+  path_part               = "{datamart_proxy+}"
+  api_gateway_usage_plans = var.api_gateway_usage_plans
+  service_url             = var.service_url
 }
 
 
@@ -229,9 +234,11 @@ module "datamart_post" {
 module "unprotected_resource" {
   source = "../resource"
 
-  rest_api_id = aws_api_gateway_rest_api.api_gw_api.id
-  parent_id   = aws_api_gateway_rest_api.api_gw_api.root_resource_id
-  path_part   = "{proxy+}"
+  rest_api_id             = aws_api_gateway_rest_api.api_gw_api.id
+  parent_id               = aws_api_gateway_rest_api.api_gw_api.root_resource_id
+  path_part               = "{proxy+}"
+  api_gateway_usage_plans = var.api_gateway_usage_plans
+  service_url             = var.service_url
 
 }
 

--- a/terraform/modules/api_gateway/gateway/variables.tf
+++ b/terraform/modules/api_gateway/gateway/variables.tf
@@ -49,16 +49,8 @@ variable "lambda_invoke_policy" {
 variable "api_gateway_usage_plans" {
   type        = map(any)
   description = "Throttling limits for API Gateway"
-  default = {
-    internal_apps = {
-      quota_limit = 1000000 # per day
-      burst_limit = 1000
-      rate_limit  = 200 # per second
-    }
-    external_apps = {
-      quota_limit = 10000
-      burst_limit = 20
-      rate_limit  = 10
-    }
-  }
+}
+
+variable "service_url" {
+  type = string
 }

--- a/terraform/modules/api_gateway/resource/main.tf
+++ b/terraform/modules/api_gateway/resource/main.tf
@@ -71,7 +71,7 @@ resource "aws_api_gateway_gateway_response" "exceeded_quota" {
   response_type = "QUOTA_EXCEEDED"
 
   response_templates = {
-    "application/json" = "{\"status\":\"failed\",\"message\":\"Exceeded the daily quota for this resource.  If you're running analysis on a list of areas of interest, please use the batch analysis endpoint to avoid this error: https://staging-data-api.globalforestwatch.org/#tag/Query/operation/query_dataset_list_post_dataset__dataset___version__query_batch_post. Otherwise, email us at gfw@wri.org to see if your use case may qualify for higher quota.\"}"
+    "application/json" = "{\"status\":\"failed\",\"message\":\"You have exceeded the daily quota of ${var.api_gateway_usage_plans.external_apps.quota_limit} requests (for non-WRI platforms) or ${var.api_gateway_usage_plans.internal_apps.quota_limit} requests (for WRI platforms) for this resource. If you are running analysis on a list of areas of interest, consider using the batch analysis endpoint to avoid this error: https://data-api.globalforestwatch.org/#tag/Query/operation/query_dataset_list_post_dataset__dataset___version__query_batch_post. If you believe your use case may qualify for a higher quota, please contact us at gfw@wri.org.\"}"
   }
 }
 
@@ -81,7 +81,7 @@ resource "aws_api_gateway_gateway_response" "throttled" {
   response_type = "THROTTLED"
 
   response_templates = {
-    "application/json" = "{\"status\":\"failed\",\"message\":\"Exceeded the rate limit for this resource. If you're running analysis on a list of areas of interest, please use the batch analysis endpoint to avoid this error: https://staging-data-api.globalforestwatch.org/#tag/Query/operation/query_dataset_list_post_dataset__dataset___version__query_batch_post. Otherwise, email us at gfw@wri.org to see if your use case may qualify for higher rate limit.\"}"
+    "application/json" = "{\"status\":\"failed\",\"message\":\"You have exceeded the daily quota of ${var.api_gateway_usage_plans.external_apps.quota_limit} requests (for non-WRI platforms) or ${var.api_gateway_usage_plans.internal_apps.quota_limit} requests (for WRI platforms) for this resource. If you are running analysis on a list of areas of interest, consider using the batch analysis endpoint to avoid this error: https://${var.service_url}/#tag/Query/operation/query_dataset_list_post_dataset__dataset___version__query_batch_post. If you believe your use case may qualify for a higher quota, please contact us at gfw@wri.org.\"}"
   }
 }
 

--- a/terraform/modules/api_gateway/resource/main.tf
+++ b/terraform/modules/api_gateway/resource/main.tf
@@ -71,7 +71,7 @@ resource "aws_api_gateway_gateway_response" "exceeded_quota" {
   response_type = "QUOTA_EXCEEDED"
 
   response_templates = {
-    "application/json" = "{\"status\":\"failed\",\"message\":\"You have exceeded the daily quota of ${var.api_gateway_usage_plans.external_apps.quota_limit} requests (for non-WRI platforms) or ${var.api_gateway_usage_plans.internal_apps.quota_limit} requests (for WRI platforms) for this resource. If you are running analysis on a list of areas of interest, consider using the batch analysis endpoint to avoid this error: https://data-api.globalforestwatch.org/#tag/Query/operation/query_dataset_list_post_dataset__dataset___version__query_batch_post. If you believe your use case may qualify for a higher quota, please contact us at gfw@wri.org.\"}"
+    "application/json" = "{\"status\":\"failed\",\"message\":\"You have exceeded the daily quota of ${var.api_gateway_usage_plans.external_apps.quota_limit} requests (for non-WRI platforms) or ${var.api_gateway_usage_plans.internal_apps.quota_limit} requests (for WRI platforms) for this resource. If you are running analysis on a list of areas of interest, consider using the batch analysis endpoint to avoid this error: https://${var.service_url}/#tag/Query/operation/query_dataset_list_post_dataset__dataset___version__query_batch_post. If you believe your use case may qualify for a higher quota, please contact us at gfw@wri.org.\"}"
   }
 }
 

--- a/terraform/modules/api_gateway/resource/main.tf
+++ b/terraform/modules/api_gateway/resource/main.tf
@@ -81,7 +81,7 @@ resource "aws_api_gateway_gateway_response" "throttled" {
   response_type = "THROTTLED"
 
   response_templates = {
-    "application/json" = "{\"status\":\"failed\",\"message\":\"You have exceeded the daily quota of ${var.api_gateway_usage_plans.external_apps.quota_limit} requests (for non-WRI platforms) or ${var.api_gateway_usage_plans.internal_apps.quota_limit} requests (for WRI platforms) for this resource. If you are running analysis on a list of areas of interest, consider using the batch analysis endpoint to avoid this error: https://${var.service_url}/#tag/Query/operation/query_dataset_list_post_dataset__dataset___version__query_batch_post. If you believe your use case may qualify for a higher quota, please contact us at gfw@wri.org.\"}"
+    "application/json" = "{\"status\":\"failed\",\"message\":\"You have exceeded the rate limit of ${var.api_gateway_usage_plans.external_apps.rate_limit} requests per second (for non-WRI platforms) or ${var.api_gateway_usage_plans.internal_apps.rate_limit} requests per second (for WRI platforms) for this resource. If you are running analysis on a list of areas of interest, consider using the batch analysis endpoint to avoid this error: https://${var.service_url}/#tag/Query/operation/query_dataset_list_post_dataset__dataset___version__query_batch_post. If you believe your use case may qualify for a higher quota, please contact us at gfw@wri.org.\"}"
   }
 }
 

--- a/terraform/modules/api_gateway/resource/variables.tf
+++ b/terraform/modules/api_gateway/resource/variables.tf
@@ -9,3 +9,12 @@ variable "parent_id" {
 variable "path_part" {
   type = string
 }
+
+variable "api_gateway_usage_plans" {
+  type        = map(any)
+  description = "Throttling limits for API Gateway"
+}
+
+variable "service_url" {
+  type = string
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -171,3 +171,21 @@ variable "data_lake_writer_instance_types" {
     "r5d.large", "r5d.xlarge", "r5d.2xlarge", "r5d.4xlarge", "r5d.8xlarge", "r5d.12xlarge", "r5d.16xlarge", "r5d.24xlarge"
   ]
 }
+
+variable "api_gateway_usage_plans" {
+  type        = map(any)
+  description = "Throttling limits for API Gateway"
+  default = {
+    internal_apps = {
+      quota_limit = 1000000 # per day
+      burst_limit = 1000
+      rate_limit  = 200 # per second
+    }
+    external_apps = {
+      quota_limit = 10000
+      burst_limit = 20
+      rate_limit  = 10
+    }
+  }
+}
+

--- a/tests_v2/unit/app/routes/datasets/test_query.py
+++ b/tests_v2/unit/app/routes/datasets/test_query.py
@@ -773,7 +773,6 @@ async def test_query_batch_feature_collection(
         headers=headers,
     )
 
-    print(response.json())
     assert response.status_code == 202
 
     data = response.json()["data"]

--- a/tests_v2/utils.py
+++ b/tests_v2/utils.py
@@ -7,6 +7,7 @@ from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
 import httpx
 from _pytest.monkeypatch import MonkeyPatch
 from fastapi.exceptions import HTTPException
+from botocore.client import BaseClient
 
 from app.application import ContextEngine
 from app.models.pydantic.authentication import User
@@ -86,7 +87,7 @@ async def invoke_lambda_mocked(
     return httpx.Response(200, json={"status": "success", "data": []})
 
 
-async def start_batch_execution_mocked(job_id: uuid.UUID, input: Dict[str, Any]):
+async def start_batch_execution_mocked(client: BaseClient, job_id: uuid.UUID, input: Dict[str, Any]):
     pass
 
 


### PR DESCRIPTION
[GTC-3322](https://gfw.atlassian.net/browse/GTC-3322)

- Fixes a bug where the `/query/batch` endpoint returned a 500 error when the request payload exceeded the 256KB limit. It now correctly returns a 400 error with error message.
- Adds the payload size limit to the api doc
- Adds the actual rate limit to the message we return for throttling response



[GTC-3322]: https://gfw.atlassian.net/browse/GTC-3322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ