### PR TITLE
Merge GTC-3337 into Production

### DIFF
--- a/app/crud/datamart.py
+++ b/app/crud/datamart.py
@@ -25,9 +25,9 @@ async def get_result(result_id: uuid.UUID) -> AnalysisResult:
     return analysis_result
 
 
-async def update_result(result_id: uuid.UUID, result_data) -> AnalysisResult:
+async def update_result(result_id: uuid.UUID, result_data: dict) -> AnalysisResult:
     analysis_result: AnalysisResult = await get_result(result_id)
-    await analysis_result.update(**json.loads(result_data.json(by_alias=False))).apply()
+    await analysis_result.update(**result_data).apply()
 
     return analysis_result
 

--- a/app/tasks/datamart/land.py
+++ b/app/tasks/datamart/land.py
@@ -98,13 +98,14 @@ async def compute_tree_cover_loss_by_driver(
                     specified_tcl_drivers_config["sql_driver_field"]
                 )
 
-        resource = TreeCoverLossByDriverUpdate(
-            result=TreeCoverLossByDriverResult.from_rows(
+        resource = {
+            "result": TreeCoverLossByDriverResult.from_rows(
                 rows=results,
                 driver_value_map=specified_tcl_drivers_config["driver_value_map"],
             ),
-            status=AnalysisStatus.saved,
-        )
+            "status": AnalysisStatus.saved,
+        }
+
         await datamart_crud.update_result(resource_id, resource)
 
     except Exception as e:
@@ -137,8 +138,10 @@ async def compute_tree_cover_loss_by_driver(
                 }
             )
         )
-        resource = TreeCoverLossByDriverUpdate(
-            status=AnalysisStatus.failed, message=str(e)
-        )
+
+        resource = {
+            "status": AnalysisStatus.failed,
+            "message": str(e),
+        }
 
         await datamart_crud.update_result(resource_id, resource)

--- a/tests_v2/unit/app/routes/datamart/test_land.py
+++ b/tests_v2/unit/app/routes/datamart/test_land.py
@@ -524,10 +524,10 @@ async def test_compute_tree_cover_loss_by_driver(geostore):
         MOCK_RESOURCE["metadata"]["aoi"]["geostore_id"] = geostore
         mock_write_result.assert_awaited_once_with(
             resource_id,
-            TreeCoverLossByDriverUpdate(
-                result=MOCK_RESOURCE["result"],
-                status=MOCK_RESOURCE["status"],
-            ),
+            {
+                "result": MOCK_RESOURCE["result"],
+                "status": MOCK_RESOURCE["status"],
+            },
         )
 
 
@@ -559,10 +559,10 @@ async def test_compute_tree_cover_loss_by_driver_error(geostore):
         )
         mock_write_error.assert_awaited_once_with(
             resource_id,
-            TreeCoverLossByDriverUpdate(
-                status=MOCK_ERROR_RESOURCE["status"],
-                message=MOCK_ERROR_RESOURCE["message"],
-            ),
+            {
+                "status": MOCK_ERROR_RESOURCE["status"],
+                "message": MOCK_ERROR_RESOURCE["message"],
+            }
         )
 
 

--- a/tests_v2/unit/app/tasks/datamart/test_tree_cover_loss_by_driver.py
+++ b/tests_v2/unit/app/tasks/datamart/test_tree_cover_loss_by_driver.py
@@ -75,8 +75,8 @@ async def test_compute_tsc_tree_cover_loss_by_driver_happy_path(
     mock_update_result.assert_awaited_once()
     update_call_args = mock_update_result.call_args.args
     assert str(update_call_args[0]) == str(test_resource_id)
-    assert update_call_args[1].status == AnalysisStatus.saved
-    assert update_call_args[1].result.tree_cover_loss_by_driver == unordered([
+    assert update_call_args[1]["status"] == AnalysisStatus.saved
+    assert update_call_args[1]["result"].tree_cover_loss_by_driver == unordered([
         {
             'drivers_type': 'Permanent agriculture',
             'loss_area_ha': 150.5, 'gross_carbon_emissions_Mg': 2500.0
@@ -86,7 +86,7 @@ async def test_compute_tsc_tree_cover_loss_by_driver_happy_path(
             'loss_area_ha': 75.2, 'gross_carbon_emissions_Mg': 1800.0
         }
     ])
-    assert update_call_args[1].result.yearly_tree_cover_loss_by_driver == unordered([
+    assert update_call_args[1]["result"].yearly_tree_cover_loss_by_driver == unordered([
         {
             'drivers_type': 'Permanent agriculture',
             'loss_year': 2020, 'loss_area_ha': 150.5,
@@ -169,8 +169,8 @@ async def test_compute_wri_google_tree_cover_loss_by_driver_happy_path(
     mock_update_result.assert_awaited_once()
     update_call_args = mock_update_result.call_args.args
     assert str(update_call_args[0]) == str(test_resource_id)
-    assert update_call_args[1].status == AnalysisStatus.saved
-    assert update_call_args[1].result.tree_cover_loss_by_driver == unordered([
+    assert update_call_args[1]["status"] == AnalysisStatus.saved
+    assert update_call_args[1]["result"].tree_cover_loss_by_driver == unordered([
         {
             'drivers_type': 'Permanent agriculture',
             'loss_area_ha': 150.5, 'gross_carbon_emissions_Mg': 2500.0
@@ -180,7 +180,7 @@ async def test_compute_wri_google_tree_cover_loss_by_driver_happy_path(
             'loss_area_ha': 75.2, 'gross_carbon_emissions_Mg': 1800.0
         }
     ])
-    assert update_call_args[1].result.yearly_tree_cover_loss_by_driver == unordered([
+    assert update_call_args[1]["result"].yearly_tree_cover_loss_by_driver == unordered([
         {
             'drivers_type': 'Permanent agriculture',
             'loss_year': 2020, 'loss_area_ha': 150.5,


### PR DESCRIPTION
Metadata is no longer being overridden in DataMart results:
```shell
curl --location 'https://staging-data-api.globalforestwatch.org/v0/land/tree_cover_loss_by_driver/26c06458-fc82-5432-8fbe-bf74d701a9f8' \
--header 'x-api-key: ***'
```

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

