### PR TITLE
:bug: fix(DataMart): explicitly convert `TreeCoverLossByDriverResult` to `dict`

### DIFF
--- a/app/tasks/datamart/land.py
+++ b/app/tasks/datamart/land.py
@@ -102,7 +102,7 @@ async def compute_tree_cover_loss_by_driver(
             "result": TreeCoverLossByDriverResult.from_rows(
                 rows=results,
                 driver_value_map=specified_tcl_drivers_config["driver_value_map"],
-            ),
+            ).dict(),
             "status": AnalysisStatus.saved,
         }
 

--- a/tests_v2/unit/app/tasks/datamart/test_tree_cover_loss_by_driver.py
+++ b/tests_v2/unit/app/tasks/datamart/test_tree_cover_loss_by_driver.py
@@ -76,7 +76,7 @@ async def test_compute_tsc_tree_cover_loss_by_driver_happy_path(
     update_call_args = mock_update_result.call_args.args
     assert str(update_call_args[0]) == str(test_resource_id)
     assert update_call_args[1]["status"] == AnalysisStatus.saved
-    assert update_call_args[1]["result"].tree_cover_loss_by_driver == unordered([
+    assert update_call_args[1]["result"]["tree_cover_loss_by_driver"] == unordered([
         {
             'drivers_type': 'Permanent agriculture',
             'loss_area_ha': 150.5, 'gross_carbon_emissions_Mg': 2500.0
@@ -86,7 +86,7 @@ async def test_compute_tsc_tree_cover_loss_by_driver_happy_path(
             'loss_area_ha': 75.2, 'gross_carbon_emissions_Mg': 1800.0
         }
     ])
-    assert update_call_args[1]["result"].yearly_tree_cover_loss_by_driver == unordered([
+    assert update_call_args[1]["result"]["yearly_tree_cover_loss_by_driver"] == unordered([
         {
             'drivers_type': 'Permanent agriculture',
             'loss_year': 2020, 'loss_area_ha': 150.5,
@@ -170,7 +170,7 @@ async def test_compute_wri_google_tree_cover_loss_by_driver_happy_path(
     update_call_args = mock_update_result.call_args.args
     assert str(update_call_args[0]) == str(test_resource_id)
     assert update_call_args[1]["status"] == AnalysisStatus.saved
-    assert update_call_args[1]["result"].tree_cover_loss_by_driver == unordered([
+    assert update_call_args[1]["result"]["tree_cover_loss_by_driver"] == unordered([
         {
             'drivers_type': 'Permanent agriculture',
             'loss_area_ha': 150.5, 'gross_carbon_emissions_Mg': 2500.0
@@ -180,7 +180,7 @@ async def test_compute_wri_google_tree_cover_loss_by_driver_happy_path(
             'loss_area_ha': 75.2, 'gross_carbon_emissions_Mg': 1800.0
         }
     ])
-    assert update_call_args[1]["result"].yearly_tree_cover_loss_by_driver == unordered([
+    assert update_call_args[1]["result"]["yearly_tree_cover_loss_by_driver"] == unordered([
         {
             'drivers_type': 'Permanent agriculture',
             'loss_year': 2020, 'loss_area_ha': 150.5,


### PR DESCRIPTION
Micro change. The error was:
```shell
(builtins.TypeError) Object of type TreeCoverLossByDriverResult is not JSON serializable [SQL: UPDATE analysis_results SET result=$1, status=$2, updated_on=$3 WHERE analysis_results.id = $4 RETURNING analysis_results.result, analysis_results.status]
```
Now we use the pydantic `dict()` method.

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [x] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

## Pull request type
Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
`TreeCoverLossByDriverResult` is not automatically converted during updates and raises an exception

Issue Number: GTC-3337


## What is the new behavior?
We use pydantic `dict()` to convert the result to a dictionary for later json conversion

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

