### PR TITLE
feat: allow admins to delete api keys

### DIFF
--- a/app/routes/authentication/authentication.py
+++ b/app/routes/authentication/authentication.py
@@ -185,8 +185,7 @@ async def delete_api_key(
             status_code=404, detail="The requested API key does not exist."
         )
 
-    # TODO: we might want to allow admins to delete api keys of other users?
-    if not row.user_id == user.id:
+    if user.role != "ADMIN" and not row.user_id == user.id:
         raise HTTPException(
             status_code=403,
             detail="The requested API key does not belong to the current user.",


### PR DESCRIPTION
Allow Admins to delete api keys

## Pull request checklist
Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [x] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

## Pull request type
Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## What is the current behavior?
Admins cannot delete API Keys

Issue Number: [GTC-3358](https://gfw.atlassian.net/browse/GTC-3358)

## What is the new behavior?
Admins can delete API Keys

## Does this introduce a breaking change?
- [ ] Yes
- [x] No

[GTC-3358]: https://gfw.atlassian.net/browse/GTC-3358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ