### PR TITLE
Add table of restricted dataset versions and deny access for those  queries

### DIFF
--- a/app/authentication/token.py
+++ b/app/authentication/token.py
@@ -1,4 +1,4 @@
-from typing import cast
+from typing import cast, Tuple, List
 
 from fastapi import Depends, HTTPException
 from fastapi.logger import logger
@@ -6,8 +6,8 @@ from fastapi.security import OAuth2PasswordBearer
 from httpx import Response
 
 from ..models.pydantic.authentication import User
-from ..routes import dataset_dependency
-from ..settings.globals import PROTECTED_QUERY_DATASETS
+from ..routes import dataset_version_dependency
+from ..settings.globals import PROTECTED_QUERY_DATASETS, PROTECTED_QUERY_DATASET_VERSIONS
 from ..utils.rw_api import who_am_i
 
 # token dependency where we immediately cause an exception if there is no auth token
@@ -40,39 +40,40 @@ async def is_admin(token: str = Depends(oauth2_scheme)) -> bool:
     User must be ADMIN for gfw app
     """
 
-    return await is_app_admin(token, "gfw", "Unauthorized")
+    return await is_app_admin(token, ["gfw"], "Unauthorized")
 
 
-async def is_gfwpro_admin_for_query(
-    dataset: str = Depends(dataset_dependency),
+async def is_admin_for_query(
+    dv: Tuple[str, str] = Depends(dataset_version_dependency),
     token: str | None = Depends(oauth2_scheme_no_auto),
 ) -> bool:
-    """If the dataset is protected dataset, calls GFW API to authorize user by
-    requiring the user must be ADMIN for gfw-pro app.
+    """If the dataset is protected dataset or the dataset/version is a protected version, calls GFW API
+    to authorize user by requiring the user must be ADMIN for gfw or gfw-pro app.
 
     If the dataset is not protected, just returns True without any
     required token or authorization.
     """
 
-    if dataset in PROTECTED_QUERY_DATASETS:
+    dataset, version = dv
+    if dataset in PROTECTED_QUERY_DATASETS or f"{dataset}/{version}" in PROTECTED_QUERY_DATASET_VERSIONS:
         if token is None:
             raise HTTPException(
-                status_code=401, detail="Unauthorized query on a restricted dataset"
+                status_code=401, detail="Unauthorized query on a restricted dataset or version"
             )
         else:
             return await is_app_admin(
                 cast(str, token),
-                "gfw-pro",
-                error_str="Unauthorized query on a restricted dataset",
+                ["gfw", "gfw-pro"],
+                error_str="Unauthorized query on a restricted dataset or version",
             )
 
     return True
 
 
-async def is_app_admin(token: str, app: str, error_str: str) -> bool:
+async def is_app_admin(token: str, apps: List[str], error_str: str) -> bool:
     """Calls GFW API to authorize user.
 
-    User must be an ADMIN for the specified app, else it will throw an
+    User must be an ADMIN for one of the specified apps, else it will throw an
     exception with the specified error string.
     """
 
@@ -80,7 +81,7 @@ async def is_app_admin(token: str, app: str, error_str: str) -> bool:
 
     if response.status_code == 401 or not (
         response.json()["role"] == "ADMIN"
-        and app in response.json()["extraUserData"]["apps"]
+        and any(app in response.json()["extraUserData"]["apps"] for app in apps)
     ):
         logger.warning(f"ADMIN privileges required. Unauthorized user: {response.text}")
         raise HTTPException(status_code=401, detail=error_str)

--- a/app/authentication/token.py
+++ b/app/authentication/token.py
@@ -43,7 +43,7 @@ async def is_admin(token: str = Depends(oauth2_scheme)) -> bool:
     return await is_app_admin(token, ["gfw"], "Unauthorized")
 
 
-async def is_admin_for_query(
+async def is_authorized_for_query(
     dv: Tuple[str, str] = Depends(dataset_version_dependency),
     token: str | None = Depends(oauth2_scheme_no_auto),
 ) -> bool:

--- a/app/routes/datasets/queries.py
+++ b/app/routes/datasets/queries.py
@@ -25,7 +25,7 @@ from app.settings.globals import API_URL
 
 from ...application import db
 from ...authentication.api_keys import get_api_key
-from ...authentication.token import is_gfwpro_admin_for_query
+from ...authentication.token import is_admin_for_query
 from ...crud import assets
 from ...models.enum.assets import AssetType
 from ...models.enum.creation_options import Delimiters
@@ -118,7 +118,7 @@ async def query_dataset_json(
     geostore_origin: GeostoreOrigin = Query(
         GeostoreOrigin.gfw, description="Service to search first for geostore."
     ),
-    is_authorized: bool = Depends(is_gfwpro_admin_for_query),
+    is_authorized: bool = Depends(is_admin_for_query),
     api_key: APIKey = Depends(get_api_key),
 ):
     """Execute a READ-ONLY SQL query on the given dataset version (if
@@ -182,7 +182,7 @@ async def query_dataset_csv(
     delimiter: Delimiters = Query(
         Delimiters.comma, description="Delimiter to use for CSV file."
     ),
-    is_authorized: bool = Depends(is_gfwpro_admin_for_query),
+    is_authorized: bool = Depends(is_admin_for_query),
     api_key: APIKey = Depends(get_api_key),
 ):
     """Execute a READ-ONLY SQL query on the given dataset version (if
@@ -245,7 +245,7 @@ async def query_dataset_json_post(
     *,
     dataset_version: Tuple[str, str] = Depends(dataset_version_dependency),
     request: QueryRequestIn,
-    is_authorized: bool = Depends(is_gfwpro_admin_for_query),
+    is_authorized: bool = Depends(is_admin_for_query),
     api_key: APIKey = Depends(get_api_key),
 ):
     """Execute a READ-ONLY SQL query on the given dataset version (if
@@ -275,7 +275,7 @@ async def query_dataset_csv_post(
     *,
     dataset_version: Tuple[str, str] = Depends(dataset_version_dependency),
     request: CsvQueryRequestIn,
-    is_authorized: bool = Depends(is_gfwpro_admin_for_query),
+    is_authorized: bool = Depends(is_admin_for_query),
     api_key: APIKey = Depends(get_api_key),
 ):
     """Execute a READ-ONLY SQL query on the given dataset version (if

--- a/app/routes/datasets/queries.py
+++ b/app/routes/datasets/queries.py
@@ -25,7 +25,7 @@ from app.settings.globals import API_URL
 
 from ...application import db
 from ...authentication.api_keys import get_api_key
-from ...authentication.token import is_admin_for_query
+from ...authentication.token import is_authorized_for_query
 from ...crud import assets
 from ...models.enum.assets import AssetType
 from ...models.enum.creation_options import Delimiters
@@ -118,7 +118,7 @@ async def query_dataset_json(
     geostore_origin: GeostoreOrigin = Query(
         GeostoreOrigin.gfw, description="Service to search first for geostore."
     ),
-    is_authorized: bool = Depends(is_admin_for_query),
+    is_authorized: bool = Depends(is_authorized_for_query),
     api_key: APIKey = Depends(get_api_key),
 ):
     """Execute a READ-ONLY SQL query on the given dataset version (if
@@ -182,7 +182,7 @@ async def query_dataset_csv(
     delimiter: Delimiters = Query(
         Delimiters.comma, description="Delimiter to use for CSV file."
     ),
-    is_authorized: bool = Depends(is_admin_for_query),
+    is_authorized: bool = Depends(is_authorized_for_query),
     api_key: APIKey = Depends(get_api_key),
 ):
     """Execute a READ-ONLY SQL query on the given dataset version (if
@@ -245,7 +245,7 @@ async def query_dataset_json_post(
     *,
     dataset_version: Tuple[str, str] = Depends(dataset_version_dependency),
     request: QueryRequestIn,
-    is_authorized: bool = Depends(is_admin_for_query),
+    is_authorized: bool = Depends(is_authorized_for_query),
     api_key: APIKey = Depends(get_api_key),
 ):
     """Execute a READ-ONLY SQL query on the given dataset version (if
@@ -275,7 +275,7 @@ async def query_dataset_csv_post(
     *,
     dataset_version: Tuple[str, str] = Depends(dataset_version_dependency),
     request: CsvQueryRequestIn,
-    is_authorized: bool = Depends(is_admin_for_query),
+    is_authorized: bool = Depends(is_authorized_for_query),
     api_key: APIKey = Depends(get_api_key),
 ):
     """Execute a READ-ONLY SQL query on the given dataset version (if

--- a/app/routes/datasets/versions.py
+++ b/app/routes/datasets/versions.py
@@ -68,6 +68,7 @@ from ...tasks.delete_assets import delete_all_assets
 from . import _verify_source_file_access
 from .dataset import get_owner
 from .queries import _get_data_environment
+from ...settings.globals import PROTECTED_QUERY_DATASET_VERSIONS
 
 router = APIRouter()
 
@@ -171,6 +172,12 @@ async def update_version(
     # if version was tagged as `latest`
     # make sure associated `latest` routes in tile cache cloud front distribution are invalidated
     if input_data.get("is_latest"):
+        if f"{dataset}/{version}" in PROTECTED_QUERY_DATASET_VERSIONS:
+            raise HTTPException(
+                status_code=409,
+                detail="Setting latest version failed."
+                "You cannot set a restricted version to be the latest version of a dataset."
+            )
         tile_cache_assets: List[ORMAsset] = await assets.get_assets_by_filter(
             dataset=dataset,
             version=version,

--- a/app/settings/globals.py
+++ b/app/settings/globals.py
@@ -183,6 +183,10 @@ GOOGLE_APPLICATION_CREDENTIALS = config(
 # commercial datasets which shouldn't be downloaded in any way.)
 PROTECTED_QUERY_DATASETS = ["wdpa_licensed_protected_areas"]
 
+# When we relax this protection on TCL2025, we should also switch the version to be
+# downloadable.
+PROTECTED_QUERY_DATASET_VERSIONS = ["umd_tree_cover_loss/v1.13"]
+
 RASTER_ANALYSIS_STATE_MACHINE_ARN = config(
     "RASTER_ANALYSIS_STATE_MACHINE_ARN", cast=str, default=None
 )

--- a/app/settings/globals.py
+++ b/app/settings/globals.py
@@ -185,7 +185,7 @@ PROTECTED_QUERY_DATASETS = ["wdpa_licensed_protected_areas"]
 
 # When we relax this protection on TCL2025, we should also switch the version to be
 # downloadable.
-PROTECTED_QUERY_DATASET_VERSIONS = ["umd_tree_cover_loss/v1.13"]
+PROTECTED_QUERY_DATASET_VERSIONS = ["umd_tree_cover_loss/v1.1", "umd_tree_cover_loss/v1.13"]
 
 RASTER_ANALYSIS_STATE_MACHINE_ARN = config(
     "RASTER_ANALYSIS_STATE_MACHINE_ARN", cast=str, default=None

--- a/app/utils/rw_api.py
+++ b/app/utils/rw_api.py
@@ -2,7 +2,7 @@ from typing import Dict
 from uuid import UUID
 
 from async_lru import alru_cache
-from fastapi import HTTPException, Response
+from fastapi import HTTPException
 from fastapi.logger import logger
 from httpx import AsyncClient, ReadTimeout
 from httpx import Response as HTTPXResponse
@@ -64,7 +64,7 @@ async def get_geostore(geostore_id: UUID) -> GeostoreCommon:
     return geostore
 
 
-async def who_am_i(token) -> Response:
+async def who_am_i(token) -> HTTPXResponse:
     """Call GFW API to get token's identity."""
 
     headers = {"Authorization": f"Bearer {token}"}

--- a/tests_v2/conftest.py
+++ b/tests_v2/conftest.py
@@ -329,7 +329,8 @@ async def restricted_version(
     """Create licensed version."""
 
     dataset_name, _ = restricted_dataset
-    version_name: str = "v1.13"
+    # Permanently restricted dataset/version umd_tree_cover_loss/v1.1 for testing purposes.
+    version_name: str = "v1.1"
 
     await create_vector_source_version(
         async_client, dataset_name, version_name, monkeypatch

--- a/tests_v2/conftest.py
+++ b/tests_v2/conftest.py
@@ -301,6 +301,70 @@ async def generic_raster_version(
 
 
 @pytest_asyncio.fixture
+async def restricted_dataset(
+    async_client: AsyncClient,
+) -> AsyncGenerator[Tuple[str, Dict[str, Any]], None]:
+    """Create licensed dataset."""
+
+    # Create dataset
+    dataset_name: str = "umd_tree_cover_loss"
+
+    await async_client.put(
+        f"/dataset/{dataset_name}", json={"metadata": DATASET_METADATA}
+    )
+
+    # Yield dataset name and associated metadata
+    yield dataset_name, DATASET_METADATA
+
+    # Clean up
+    await async_client.delete(f"/dataset/{dataset_name}")
+
+
+@pytest_asyncio.fixture
+async def restricted_version(
+    async_client: AsyncClient,
+    restricted_dataset: Tuple[str, str],
+    monkeypatch: MonkeyPatch,
+) -> AsyncGenerator[Tuple[str, str, Dict[str, Any]], None]:
+    """Create licensed version."""
+
+    dataset_name, _ = restricted_dataset
+    version_name: str = "v1.13"
+
+    await create_vector_source_version(
+        async_client, dataset_name, version_name, monkeypatch
+    )
+
+    # yield version
+    yield dataset_name, version_name, VERSION_METADATA
+
+    # clean up
+    await async_client.delete(f"/dataset/{dataset_name}/{version_name}")
+
+
+@pytest_asyncio.fixture
+async def unrestricted_version(
+    async_client: AsyncClient,
+    restricted_dataset: Tuple[str, str],
+    monkeypatch: MonkeyPatch,
+) -> AsyncGenerator[Tuple[str, str, Dict[str, Any]], None]:
+    """Create licensed version."""
+
+    dataset_name, _ = restricted_dataset
+    version_name: str = "v1.12"
+
+    await create_vector_source_version(
+        async_client, dataset_name, version_name, monkeypatch
+    )
+
+    # yield version
+    yield dataset_name, version_name, VERSION_METADATA
+
+    # clean up
+    await async_client.delete(f"/dataset/{dataset_name}/{version_name}")
+
+
+@pytest_asyncio.fixture
 async def licensed_dataset(
     async_client: AsyncClient,
 ) -> AsyncGenerator[Tuple[str, Dict[str, Any]], None]:

--- a/tests_v2/unit/app/routes/datasets/test_query.py
+++ b/tests_v2/unit/app/routes/datasets/test_query.py
@@ -35,6 +35,12 @@ from tests_v2.utils import (
     start_batch_execution_mocked,
 )
 
+def get_headers_with_origin(apikey):
+    api_key, payload = apikey
+    origin = "https://" + payload["domains"][0]
+    headers = {"origin": origin, "x-api-key": api_key}
+    return headers
+
 
 @pytest.mark.skip("Temporarily skip until we require API keys")
 @pytest.mark.asyncio
@@ -56,16 +62,12 @@ async def test_query_dataset_with_api_key(
     generic_vector_source_version, apikey, async_client: AsyncClient
 ):
     dataset_name, version_name, _ = generic_vector_source_version
-    api_key, payload = apikey
-    origin = "https://" + payload["domains"][0]
-
-    headers = {"origin": origin, "x-api-key": api_key}
     params = {"sql": "select count(*) as count from data"}
 
     response = await async_client.get(
         f"/dataset/{dataset_name}/{version_name}/query",
         params=params,
-        headers=headers,
+        headers=get_headers_with_origin(apikey),
         follow_redirects=True,
     )
 
@@ -123,10 +125,6 @@ async def test_query_dataset_raster_bad_get(
     async_client: AsyncClient,
 ):
     dataset_name, version_name, _ = generic_raster_version
-    api_key, payload = apikey
-    origin = "https://" + payload["domains"][0]
-
-    headers = {"origin": origin, "x-api-key": api_key}
 
     monkeypatch.setattr(queries, "invoke_lambda", invoke_lambda_mocked)
     params = {"sql": "select count(*) from data", "geostore_id": geostore_bad}
@@ -134,7 +132,7 @@ async def test_query_dataset_raster_bad_get(
     response = await async_client.get(
         f"/dataset/{dataset_name}/{version_name}/query",
         params=params,
-        headers=headers,
+        headers=get_headers_with_origin(apikey),
         follow_redirects=True,
     )
 
@@ -150,10 +148,6 @@ async def test_query_dataset_raster_get(
     async_client: AsyncClient,
 ):
     dataset_name, version_name, _ = generic_raster_version
-    api_key, payload = apikey
-    origin = "https://" + payload["domains"][0]
-
-    headers = {"origin": origin, "x-api-key": api_key}
 
     monkeypatch.setattr(queries, "invoke_lambda", invoke_lambda_mocked)
     params = {"sql": "select count(*) from data", "geostore_id": geostore}
@@ -161,7 +155,7 @@ async def test_query_dataset_raster_get(
     response = await async_client.get(
         f"/dataset/{dataset_name}/{version_name}/query",
         params=params,
-        headers=headers,
+        headers=get_headers_with_origin(apikey),
         follow_redirects=True,
     )
 
@@ -178,10 +172,6 @@ async def test_query_dataset_raster_post(
     async_client: AsyncClient,
 ):
     dataset_name, version_name, _ = generic_raster_version
-    api_key, payload = apikey
-    origin = "https://" + payload["domains"][0]
-
-    headers = {"origin": origin, "x-api-key": api_key}
 
     monkeypatch.setattr(queries, "invoke_lambda", invoke_lambda_mocked)
     payload = {
@@ -192,7 +182,7 @@ async def test_query_dataset_raster_post(
     response = await async_client.post(
         f"/dataset/{dataset_name}/{version_name}/query",
         json=payload,
-        headers=headers,
+        headers=get_headers_with_origin(apikey),
         follow_redirects=True,
     )
 
@@ -209,10 +199,6 @@ async def test_redirect_post_query(
     async_client: AsyncClient,
 ):
     dataset_name, version_name, _ = generic_raster_version
-    api_key, payload = apikey
-    origin = "https://" + payload["domains"][0]
-
-    headers = {"origin": origin, "x-api-key": api_key}
 
     monkeypatch.setattr(queries, "invoke_lambda", invoke_lambda_mocked)
     payload = {
@@ -222,7 +208,7 @@ async def test_redirect_post_query(
 
     response = await async_client.post(
         f"/dataset/{dataset_name}/{version_name}/query",
-        headers=headers,
+        headers=get_headers_with_origin(apikey),
         json=payload,
         follow_redirects=False,
     )
@@ -243,17 +229,13 @@ async def test_redirect_get_query(
     async_client: AsyncClient,
 ):
     dataset_name, version_name, _ = generic_raster_version
-    api_key, payload = apikey
-    origin = "https://" + payload["domains"][0]
-
-    headers = {"origin": origin, "x-api-key": api_key}
 
     monkeypatch.setattr(queries, "invoke_lambda", invoke_lambda_mocked)
     params = {"sql": "select count(*) from data", "geostore_id": geostore}
 
     response = await async_client.get(
         f"/dataset/{dataset_name}/{version_name}/query",
-        headers=headers,
+        headers=get_headers_with_origin(apikey),
         params=params,
         follow_redirects=False,
     )
@@ -276,15 +258,11 @@ async def test_query_dataset_raster_geostore_huge(
     async_client: AsyncClient,
 ):
     dataset_name, version_name, _ = generic_raster_version
-    api_key, payload = apikey
-    origin = "https://" + payload["domains"][0]
-
-    headers = {"origin": origin, "x-api-key": api_key}
     params = {"sql": "select count(*) from data", "geostore_id": geostore_huge}
     response = await async_client.get(
         f"/dataset/{dataset_name}/{version_name}/query",
         params=params,
-        headers=headers,
+        headers=get_headers_with_origin(apikey),
         follow_redirects=True,
     )
 
@@ -297,13 +275,9 @@ async def test_query_vector_asset_sql_value_functions_disallowed(
 ):
     dataset, version, _ = generic_vector_source_version
 
-    api_key, payload = apikey
-    origin = "https://" + payload["domains"][0]
-    headers = {"origin": origin, "x-api-key": api_key}
-
     response = await async_client.get(
         f"/dataset/{dataset}/{version}/query?sql=select current_catalog from mytable;",
-        headers=headers,
+        headers=get_headers_with_origin(apikey),
         follow_redirects=True,
     )
     assert response.status_code == 400
@@ -316,13 +290,9 @@ async def test_query_vector_asset_sys_functions_disallowed(
 ):
     dataset, version, _ = generic_vector_source_version
 
-    api_key, payload = apikey
-    origin = "https://" + payload["domains"][0]
-    headers = {"origin": origin, "x-api-key": api_key}
-
     response = await async_client.get(
         f"/dataset/{dataset}/{version}/query?sql=select version() from mytable;",
-        headers=headers,
+        headers=get_headers_with_origin(apikey),
         follow_redirects=True,
     )
     assert response.status_code == 400
@@ -338,13 +308,9 @@ async def test_query_vector_asset_unknown_functions_disallowed(
 ):
     dataset, version, _ = generic_vector_source_version
 
-    api_key, payload = apikey
-    origin = "https://" + payload["domains"][0]
-    headers = {"origin": origin, "x-api-key": api_key}
-
     response = await async_client.get(
         f"/dataset/{dataset}/{version}/query?sql=select doesnotexist() from mytable;",
-        headers=headers,
+        headers=get_headers_with_origin(apikey),
         follow_redirects=True,
     )
     assert response.status_code == 400
@@ -356,22 +322,47 @@ async def test_query_vector_asset_unknown_functions_disallowed(
 
 
 @pytest.mark.asyncio()
-async def test_query_licensed_disallowed_11(
+async def test_query_licensed_disallowed(
     licensed_version, apikey, async_client: AsyncClient
 ):
     dataset, version, _ = licensed_version
-
-    api_key, payload = apikey
-    origin = "https://" + payload["domains"][0]
-    headers = {"origin": origin, "x-api-key": api_key}
-
     response = await async_client.get(
         f"/dataset/{dataset}/{version}/query?sql=select(*) from mytable;",
-        headers=headers,
+        headers=get_headers_with_origin(apikey),
         follow_redirects=True,
     )
     assert response.status_code == 401
-    assert response.json()["message"] == ("Unauthorized query on a restricted dataset")
+    assert response.json()["message"] == ("Unauthorized query on a restricted dataset or version")
+
+
+@pytest.mark.asyncio()
+async def test_query_restricted_version_disallowed(
+        restricted_version, unrestricted_version, apikey,
+        geostore, monkeypatch: MonkeyPatch, async_client: AsyncClient,
+):
+    # Test for an error if accessing a restricted version of a dataset.
+    dataset, version, _ = restricted_version
+    response = await async_client.get(
+        f"/dataset/{dataset}/{version}/query?sql=select(*) from mytable;",
+        headers=get_headers_with_origin(apikey),
+        follow_redirects=True,
+    )
+    assert response.status_code == 401
+    assert response.json()["message"] == ("Unauthorized query on a restricted dataset or version")
+
+    # Test for no error if accessing an unrestricted version of the same dataset that
+    # has a restricted version.
+    monkeypatch.setattr(queries, "invoke_lambda", invoke_lambda_mocked)
+
+    dataset, version, _ = unrestricted_version
+    params = {"sql": "select count(*) from data", "geostore_id": geostore}
+    response = await async_client.get(
+        f"/dataset/{dataset}/{version}/query",
+        params=params,
+        headers=get_headers_with_origin(apikey),
+        follow_redirects=True,
+    )
+    assert response.status_code == 200
 
 
 @pytest.mark.asyncio
@@ -602,10 +593,6 @@ async def test_query_batch_feature_collection(
     async_client: AsyncClient,
 ):
     dataset_name, version_name, _ = generic_raster_version
-    api_key, payload = apikey
-    origin = "https://" + payload["domains"][0]
-
-    headers = {"origin": origin, "x-api-key": api_key}
 
     monkeypatch.setattr(queries, "_start_batch_execution", start_batch_execution_mocked)
     payload = {
@@ -617,7 +604,7 @@ async def test_query_batch_feature_collection(
     response = await async_client.post(
         f"/dataset/{dataset_name}/{version_name}/query/batch",
         json=payload,
-        headers=headers,
+        headers=get_headers_with_origin(apikey),
     )
 
     assert response.status_code == 202
@@ -646,10 +633,6 @@ async def test_query_batch_uri(
     async_client: AsyncClient,
 ):
     dataset_name, version_name, _ = generic_raster_version
-    api_key, payload = apikey
-    origin = "https://" + payload["domains"][0]
-
-    headers = {"origin": origin, "x-api-key": api_key}
 
     monkeypatch.setattr(queries, "_start_batch_execution", start_batch_execution_mocked)
     monkeypatch.setattr(queries, "_verify_source_file_access", lambda source_uris: True)
@@ -663,7 +646,7 @@ async def test_query_batch_uri(
     response = await async_client.post(
         f"/dataset/{dataset_name}/{version_name}/query/batch",
         json=payload,
-        headers=headers,
+        headers=get_headers_with_origin(apikey),
     )
 
     print(response.json())


### PR DESCRIPTION
Add table of restricted dataset versions and deny access for those  queries

This is analogous to the query permission check we already have for restricted datasets (which has only ever been
"wdpa_licensed_protected_areas"). I am just implementing a permission check for specific restricted dataset/versions as well.

I already added a restricted version umd_tree_cover_loss/v1.13, so that will prevent access to TCL2025 (until we remove the restriction), unless the query supplied a bearer token with ADMIN privileges for either gfw-pro or gfw-apps.

New test is test_query_restricted_version_disallowed, but I also made a re-factoring change to pull out common code from a bunch of the tests into a small helper function get_headers_with_origin.
