### PR TITLE
Fix minor issues preventing use of numpy >= 2

### DIFF
--- a/app/routes/datasets/queries.py
+++ b/app/routes/datasets/queries.py
@@ -745,7 +745,7 @@ def _get_date_conf_derived_layers(
         DerivedLayer(
             source_layer=source_layer_name,
             name=source_layer_name.replace("__date_conf", "__date"),
-            calc="A % 10000",
+            calc="A.astype(uint16) % 10000",
             no_data=no_data_val,
             decode_expression=decode_expression,
             encode_expression=encode_expression,
@@ -753,7 +753,7 @@ def _get_date_conf_derived_layers(
         DerivedLayer(
             source_layer=source_layer_name,
             name=source_layer_name.replace("__date_conf", "__confidence"),
-            calc="floor(A / 10000).astype(uint8)",
+            calc="floor(A.astype(uint16) / 10000).astype(uint8)",
             no_data=no_data_val,
             raster_table=conf_encoding,
         ),

--- a/tests_v2/fixtures/otf_payload/otf_payload.py
+++ b/tests_v2/fixtures/otf_payload/otf_payload.py
@@ -16,7 +16,7 @@ environment = [
         "decode_expression": "(A.astype('timedelta64[D]') + datetime64('2015-01-01', 'D')).astype(str)",
         "encode_expression": "(datetime64(A, 'D') - datetime64('2015-01-01', 'D')).astype(uint16)",
         "source_layer": "my_first_dataset__date_conf",
-        "calc": "A % 10000",
+        "calc": "A.astype(uint16) % 10000",
     },
     {
         "name": "my_first_dataset__confidence",
@@ -32,7 +32,7 @@ environment = [
         "decode_expression": "",
         "encode_expression": "",
         "source_layer": "my_first_dataset__date_conf",
-        "calc": "floor(A / 10000).astype(uint8)",
+        "calc": "floor(A.astype(uint16) / 10000).astype(uint8)",
     },
 ]
 


### PR DESCRIPTION
When upgrading to Numpy 2 all seems fine at first. When calling the raster analysis lambda (via the query route), however, one gets a cryptic 500 back. Apparently Numpy 2 is more strict about promoting data types. I will try to reproduce the exact error this fixes and add it here.