### PR TITLE
Fix load_tabular_data.sh depending on undefined behavior (which has started breaking)

### DIFF
--- a/batch/scripts/load_tabular_data.sh
+++ b/batch/scripts/load_tabular_data.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 
 set -e
+# Without pipefail, a pipeline's exit status is just its last command's,
+# so e.g. `aws s3 cp ... | sed ...` would report success even if the
+# download itself failed. We rely on failures from any stage of any
+# pipe in this script (aws s3 cp, sed, psql) being visible.
+set -o pipefail
 
 # requires arguments
 # -d | --dataset
@@ -42,22 +47,54 @@ fi
 
 for uri in "${SRC[@]}"; do
 # https://stackoverflow.com/questions/48019381/how-postgresql-copy-to-stdin-with-csv-do-on-conflic-do-update
-  aws s3 cp "${uri}" - | psql -c "BEGIN;
-    CREATE TEMP TABLE \"$TEMP_TABLE\"
-    (LIKE \"$DATASET\".\"$VERSION\" INCLUDING DEFAULTS)
-    ON COMMIT DROP;
+#
+# NOTE: `psql -c "...COPY ... FROM STDIN...more SQL..."` is NOT reliable
+# when the COPY isn't the LAST statement in the string -- psql's -c
+# handling of multiple bundled commands is documented as producing
+# "unexpected results" (https://postgresql.org/message-id/5466.1392310398%40sss.pgh.pa.us),
+# and in practice it can abort the connection outright as soon as it
+# hits the COPY ("unexpected COPY_IN result, aborting connection")
+# without ever reading any data.
+#
+# Instead we feed psql ONE continuous script over its real stdin: the
+# header SQL (ending in the COPY statement), then the streamed S3 data,
+# then an explicit end-of-copy marker (\.), then the trailer SQL that
+# finishes the transaction. This is the same pattern as
+# `psql -f <(cat header.sql data.csv footer.sql)`, just streamed
+# instead of buffered so we don't have to hold the whole file in memory.
+  {
+    cat <<EOSQL
+BEGIN;
 
-    ALTER TABLE \"$TEMP_TABLE\" DROP COLUMN IF EXISTS ${GEOMETRY_NAME};
-    ALTER TABLE \"$TEMP_TABLE\" DROP COLUMN IF EXISTS ${GEOMETRY_NAME}_wm;
+CREATE TEMP TABLE "$TEMP_TABLE"
+(LIKE "$DATASET"."$VERSION" INCLUDING DEFAULTS)
+ON COMMIT DROP;
 
-    COPY \"$TEMP_TABLE\" FROM STDIN WITH (FORMAT CSV, DELIMITER '$DELIMITER', HEADER);
+ALTER TABLE "$TEMP_TABLE" DROP COLUMN IF EXISTS ${GEOMETRY_NAME};
+ALTER TABLE "$TEMP_TABLE" DROP COLUMN IF EXISTS ${GEOMETRY_NAME}_wm;
 
-    $ADD_POINT_GEOMETRY_FIELDS_SQL
-    $FILL_POINT_GEOMETRY_FIELDS_SQL
+COPY "$TEMP_TABLE" FROM STDIN WITH (FORMAT CSV, DELIMITER '$DELIMITER', HEADER);
+EOSQL
 
-    INSERT INTO \"$DATASET\".\"$VERSION\"
-    SELECT * FROM \"$TEMP_TABLE\"
-    ON CONFLICT DO NOTHING;
+    # Stream the source data straight through, normalizing it to end in
+    # exactly one newline. GNU sed appends a trailing newline only when
+    # one is missing, and passes an existing one through unchanged --
+    # this keeps the \. marker below cleanly on its own line without
+    # ever introducing a spurious blank data row (which COPY would
+    # otherwise choke on for any table with more than one column).
+    aws s3 cp "${uri}" - | sed -e '$a\'
 
-    COMMIT;"
+    cat <<EOSQL
+\.
+
+$ADD_POINT_GEOMETRY_FIELDS_SQL
+$FILL_POINT_GEOMETRY_FIELDS_SQL
+
+INSERT INTO "$DATASET"."$VERSION"
+SELECT * FROM "$TEMP_TABLE"
+ON CONFLICT DO NOTHING;
+
+COMMIT;
+EOSQL
+  } | psql -v ON_ERROR_STOP=1
 done


### PR DESCRIPTION
## The symptom:
`test_table_source_asset_minimal` (and any tabular data load using `load_tabular_data.sh`) intermittently failed with the batch job reporting `status: failed`. The job logs showed `BEGIN`, `CREATE TABLE`, and both `ALTER TABLE` statements succeeding, then immediately `unexpected COPY_IN result, aborting connection` from psql, followed by `download failed: ... [Errno 32] Broken pipe` from the `aws s3 cp` side of the pipe — with no data ever actually loaded.

## The issue:
`load_tabular_data.sh` piped `aws s3 cp ... -` into `psql -c "BEGIN; ...; COPY \"$TEMP_TABLE\" FROM STDIN ...; ...; INSERT ...; COMMIT;"` — a single `-c` string bundling multiple statements with `COPY FROM STDIN` in the *middle* rather than last. This is a documented limitation of `psql -c`: bundling more than one command, with a `COPY` not in the final position, produces "unexpected results" (per PostgreSQL's own maintainers), and here it manifested as psql aborting the connection the instant it entered copy mode, before reading any data. `psql` closing its end of the pipe first is also what produced the "Broken pipe" on the `aws s3 cp` side — a downstream symptom, not the root cause. Since `create_tabular_schema.sh` has no `COPY` statement, it was unaffected, which is why only the load step failed.

## The fix:
Restructure the script to feed psql one continuous script over its real stdin instead of via `-c`: header SQL ending in the `COPY` statement, then the streamed S3 data, then an explicit `\.` end-of-copy marker, then the trailer SQL (`INSERT ... COMMIT`) — the same pattern as `psql -f <(cat header.sql data.csv footer.sql)`, kept streaming rather than buffered. The data is piped through `sed -e '$a\'` first so it always ends in exactly one newline (verified against both a normally-terminated and a missing-trailing-newline fixture), which keeps the `\.` marker on its own line without ever risking a spurious blank row that would break `COPY` on a multi-column table. Also added `set -o pipefail`, since without it a failed `aws s3 cp` could be silently masked by a later stage in the same pipe succeeding, and `psql -v ON_ERROR_STOP=1` to preserve fail-fast behavior on SQL errors.

## Why now?:
The code has been (at least mostly) working for a few years but just started CONSISTENTLY breaking now. I would guess, but am not sure, that Ubuntu upgraded the PostgreSQL package to one which changed the undefined behavior in practice. Actually, Claude says that Ubuntu Noble did just go from PostgreSQL 15 to PostgreSQL 16.