### PR TITLE
Build ARM PostGIS image for CI and laptops

### DIFF
--- a/.github/workflows/test_fixture_images.yaml
+++ b/.github/workflows/test_fixture_images.yaml
@@ -1,0 +1,46 @@
+name: Build and publish PostGIS test image
+
+# The postgis/postgis image has no arm64 build, but PostgreSQL does. Build here
+# and push to GHCR so that we can use it in our tests on arm64 runners and
+# our laptops.
+# Only runs when docker/postgis/** actually changes -- the Dockerfile
+# rarely changes, so there's no reason to run this on every push.
+on:
+  push:
+    paths:
+      - "docker/postgis/**"
+  workflow_dispatch: {}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Needed to cross-build the arm64 half of this image on this x64
+      # runner
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: ./docker/postgis
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ghcr.io/wri/gfw-data-api-postgis-test:latest

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -2,4 +2,4 @@
 line_length = 88
 multi_line_output = 3
 include_trailing_comma = True
-known_third_party = _pytest,aenum,affine,alembic,asgi_lifespan,async_lru,asyncpg,aws_utils,boto3,botocore,click,docker,ee,errors,fastapi,fiona,gdal_utils,geoalchemy2,geojson,gfw_pixetl,gino,gino_starlette,google,httpx,httpx_auth,jsonschema,logger,logging_utils,moto,numpy,orjson,osgeo,pandas,pendulum,pglast,psutil,psycopg2,pydantic,pyproj,pytest,pytest_asyncio,pytest_unordered,rasterio,shapely,sqlalchemy,sqlalchemy_utils,starlette,tileputty,tiles_geojson,typer,unidecode
+known_third_party = _pytest,aenum,affine,alembic,asgi_lifespan,async_lru,asyncpg,aws_utils,boto3,botocore,click,ee,errors,fastapi,fiona,gdal_utils,geoalchemy2,geojson,gfw_pixetl,gino,gino_starlette,google,httpx,httpx_auth,jsonschema,logger,logging_utils,moto,numpy,orjson,osgeo,pandas,pendulum,pglast,psutil,psycopg2,pydantic,pyproj,pytest,pytest_asyncio,pytest_unordered,rasterio,shapely,sqlalchemy,sqlalchemy_utils,starlette,tileputty,tiles_geojson,typer,unidecode

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -61,7 +61,9 @@ services:
 
   database_14:
     container_name: gfw-data-api-database_14
-    image: postgis/postgis:14-3.4-alpine
+    build:
+      context: ./docker/postgis
+    image: gfw-data-api-postgis:latest
     restart: on-failure
     ports:
       - "54320:5432"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -46,7 +46,9 @@ services:
 
   database:
     container_name: gfw-data-api-database
-    image: postgis/postgis:14-3.4-alpine
+    build:
+      context: ./docker/postgis
+    image: gfw-data-api-postgis:latest
     restart: on-failure
     ports:
       - "54320:5432"

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -72,7 +72,9 @@ services:
 
   test_database_14:
     container_name: gfw-data-api-test-database-14
-    image: postgis/postgis:14-3.4-alpine
+    build:
+      context: ./docker/postgis
+    image: gfw-data-api-postgis:latest
     ports:
       - "54321:5432"
     environment:

--- a/docker/postgis/Dockerfile
+++ b/docker/postgis/Dockerfile
@@ -1,0 +1,35 @@
+# Multi-arch (amd64 + arm64) PostgreSQL + PostGIS image, used by
+# docker-compose.{dev,prod,test}.yml.
+#
+# postgis/postgis:14-3.4-alpine (and any other PostGIS image up to at least
+# PostgreSQL 16.x, both Alpine and Debian variants) has no arm64 variant, so
+# it can't be used on Apple laptops or other arm64 hosts except under
+# emulation. Emulating a database doing lots of syscalls/fsync/shared-memory
+# work is much slower than emulating typical CPU-bound application code,
+# and this has a dramatic effect on test suite runtimes.
+#
+# The official `postgres` image, unlike postgis/postgis, IS multi-arch.
+# This Dockerfile installs PostGIS on top of it via the PGDG
+# apt repository. As of PG_VERSION=14, PGDG publishes PostGIS 3.4.1 for Postgres
+# 14 on bookworm, explicitly including arm64 (unlike Debian's own default
+# archive, whose bookworm PostGIS package lags behind and isn't guaranteed
+# to track a specific PostGIS minor version).
+ARG PG_VERSION=14
+
+FROM postgres:${PG_VERSION}-bookworm
+
+ARG PG_VERSION
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl ca-certificates \
+    && install -d /usr/share/postgresql-common/pgdg \
+    && curl -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc \
+         --fail https://www.postgresql.org/media/keys/ACCC4CF8.asc \
+    && echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt bookworm-pgdg main" \
+         > /etc/apt/sources.list.d/pgdg.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+         postgresql-${PG_VERSION}-postgis-3 \
+         postgresql-${PG_VERSION}-postgis-3-scripts \
+    && apt-get purge -y --auto-remove curl \
+    && rm -rf /var/lib/apt/lists/*

--- a/scripts/test
+++ b/scripts/test
@@ -62,6 +62,19 @@ fi
 if [ "${BUILD}" = true ]; then
   docker build -t batch_jobs_test . -f batch/universal_batch.dockerfile
   docker build -t pixetl_test . -f batch/pixetl.dockerfile
+  # Best-effort: pull the pre-built, public, multi-arch PostGIS test image
+  # from GHCR (see .github/workflows/test_fixture_images.yaml) and retag it
+  # locally, so the `docker compose build` below hits Docker's local layer
+  # cache instead of rebuilding docker/postgis/Dockerfile from scratch
+  # (a full `dnf install` on a cold cache). Purely an optimization -- if
+  # this fails for any reason (offline, package not public yet, whatever),
+  # the build below just proceeds as a normal full build, same as if this
+  # step didn't exist. Needs no credentials either way: the image is public,
+  # and a failed anonymous pull degrades gracefully rather than erroring.
+  if docker pull ghcr.io/wri/gfw-data-api-postgis-test:latest > /dev/null 2>&1; then
+    docker tag ghcr.io/wri/gfw-data-api-postgis-test:latest gfw-data-api-postgis:latest
+  fi
+  docker compose -f docker-compose.test.yml --project-name gfw-data-api_test build test_database_14
   docker compose -f docker-compose.test.yml --project-name gfw-data-api_test build --no-cache app_test
 fi
 

--- a/scripts/test
+++ b/scripts/test
@@ -62,17 +62,12 @@ fi
 if [ "${BUILD}" = true ]; then
   docker build -t batch_jobs_test . -f batch/universal_batch.dockerfile
   docker build -t pixetl_test . -f batch/pixetl.dockerfile
-  # Best-effort: pull the pre-built, public, multi-arch PostGIS test image
-  # from GHCR (see .github/workflows/test_fixture_images.yaml) and retag it
-  # locally, so the `docker compose build` below hits Docker's local layer
-  # cache instead of rebuilding docker/postgis/Dockerfile from scratch
-  # (a full `dnf install` on a cold cache). Purely an optimization -- if
-  # this fails for any reason (offline, package not public yet, whatever),
-  # the build below just proceeds as a normal full build, same as if this
-  # step didn't exist. Needs no credentials either way: the image is public,
-  # and a failed anonymous pull degrades gracefully rather than erroring.
   if docker pull ghcr.io/wri/gfw-data-api-postgis-test:latest > /dev/null 2>&1; then
+    cached_digest=$(docker inspect --format '{{index .RepoDigests 0}}' ghcr.io/wri/gfw-data-api-postgis-test:latest 2>/dev/null || echo "unknown")
+    echo "Pulled cached PostGIS test image from GHCR: ${cached_digest}"
     docker tag ghcr.io/wri/gfw-data-api-postgis-test:latest gfw-data-api-postgis:latest
+  else
+    echo "No cached PostGIS test image available from GHCR (offline, not public yet, or a genuine miss) -- building from scratch."
   fi
   docker compose -f docker-compose.test.yml --project-name gfw-data-api_test build test_database_14
   docker compose -f docker-compose.test.yml --project-name gfw-data-api_test build --no-cache app_test

--- a/scripts/test_v2
+++ b/scripts/test_v2
@@ -57,14 +57,12 @@ if [ "${BUILD}" = true ]; then
   # tests_v2/ never references either image -- only tests/conftest.py
   # registers them as mock AWS Batch job definitions, for v1's tests that
   # actually run local Docker containers to simulate Batch job execution.
-  #
-  # Best-effort: pull the pre-built, public, multi-arch PostGIS test image
-  # from GHCR (see .github/workflows/test_fixture_images.yaml) and retag it
-  # locally, so the `docker compose build` below hits Docker's local layer
-  # cache instead of rebuilding docker/postgis/Dockerfile from scratch.
-  # See scripts/test's identical step for the full explanation.
   if docker pull ghcr.io/wri/gfw-data-api-postgis-test:latest > /dev/null 2>&1; then
+    cached_digest=$(docker inspect --format '{{index .RepoDigests 0}}' ghcr.io/wri/gfw-data-api-postgis-test:latest 2>/dev/null || echo "unknown")
+    echo "Pulled cached PostGIS test image from GHCR: ${cached_digest}"
     docker tag ghcr.io/wri/gfw-data-api-postgis-test:latest gfw-data-api-postgis:latest
+  else
+    echo "No cached PostGIS test image available from GHCR (offline, not public yet, or a genuine miss) -- building from scratch."
   fi
   docker compose -f docker-compose.test.yml --project-name gfw-data-api_test build test_database_14
   docker compose -f docker-compose.test.yml --project-name gfw-data-api_test build --no-cache app_test

--- a/scripts/test_v2
+++ b/scripts/test_v2
@@ -57,8 +57,16 @@ if [ "${BUILD}" = true ]; then
   # tests_v2/ never references either image -- only tests/conftest.py
   # registers them as mock AWS Batch job definitions, for v1's tests that
   # actually run local Docker containers to simulate Batch job execution.
-  # Building those two large, uncached GDAL-based images here was pure
-  # wasted time.
+  #
+  # Best-effort: pull the pre-built, public, multi-arch PostGIS test image
+  # from GHCR (see .github/workflows/test_fixture_images.yaml) and retag it
+  # locally, so the `docker compose build` below hits Docker's local layer
+  # cache instead of rebuilding docker/postgis/Dockerfile from scratch.
+  # See scripts/test's identical step for the full explanation.
+  if docker pull ghcr.io/wri/gfw-data-api-postgis-test:latest > /dev/null 2>&1; then
+    docker tag ghcr.io/wri/gfw-data-api-postgis-test:latest gfw-data-api-postgis:latest
+  fi
+  docker compose -f docker-compose.test.yml --project-name gfw-data-api_test build test_database_14
   docker compose -f docker-compose.test.yml --project-name gfw-data-api_test build --no-cache app_test
 fi
 


### PR DESCRIPTION
While making my ARM support branch it became obvious that there is no official ARM version of the PostGIS image we use. This meant that it needed to be emulated during tests on ARM (laptops and ARM GHA runners), which more than tripled the run time in CI! Fortunately PostgreSQL has a multi-arch image and it was easy enough to make a multi-arch PostGIS one from that. This PR builds it and caches it in GHCR, and has the test scripts pull that (falling back on building it locally).

Even if we don't switch to ARM instances, this will reduce test running time for those of us on ARM laptops.