### PR TITLE
Mock PixETL functions in tests and remove it as a dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,12 +52,7 @@ dependencies = [
 dev = [
     "asgi-lifespan",
     "docker",
-    "geopandas", # Needed by pixetl in batch script test
-    # Pixetl is already installed in the pixetl image that's run in Batch,
-    # this is to enable tests to run in the test container:
-    "gfw-pixetl",
     "moto[awslambda, batch, ec2, s3, secretsmanager]<5",
-    "pandas<2.2", # Needed by pixetl in batch script test
     "pre-commit",
     "pytest",
     "pytest-asyncio",
@@ -65,11 +60,7 @@ dev = [
     "pytest-timeout",
     "pytest-unordered>=0.6.1",
     "rasterio==1.4.3",
-    "retrying", # Needed by pixetl in batch script test
 ]
 
 [tool.setuptools]
 packages = ["app", "batch"]
-
-[tool.uv.sources]
-gfw-pixetl = { git = "https://github.com/wri/gfw_pixetl.git", branch = "develop" }

--- a/tests_v2/unit/batch/python/test_resample.py
+++ b/tests_v2/unit/batch/python/test_resample.py
@@ -1,18 +1,73 @@
 import logging
-from typing import Any, List, Tuple
+import sys
+from types import ModuleType
+from typing import Any, Dict, List, Tuple
+from unittest.mock import Mock, patch
 
 import boto3
 import pytest
-
-from app.settings.globals import AWS_GCS_KEY_SECRET_ARN, AWS_REGION, AWS_SECRETSMANAGER_URL
 from pyproj import CRS
 
+from app.settings.globals import (
+    AWS_GCS_KEY_SECRET_ARN,
+    AWS_REGION,
+    AWS_SECRETSMANAGER_URL,
+)
 
 MODULE_PATH_UNDER_TEST = "batch.python.resample"
 
 
+GRID_TILE_BOUNDS: Dict[str, Dict[str, Tuple[float, float, float, float]]] = {
+    "zoom_12": {
+        "002R_002C": (
+            -15028131.257091934,
+            12523442.714399263,
+            -12523442.714243278,
+            15028131.257279117,
+        ),
+        "002R_003C": (
+            -12523442.714243278,
+            12523442.714399263,
+            -10018754.171394622,
+            15028131.257279117,
+        ),
+        "003R_002C": (
+            -15028131.257091934,
+            10018754.17151941,
+            -12523442.714243278,
+            12523442.714399263,
+        ),
+        "003R_003C": (
+            -12523442.714243278,
+            10018754.17151941,
+            -10018754.171394622,
+            12523442.714399263,
+        ),
+    },
+    "zoom_11": {
+        "001R_001C": (
+            -15028131.257091934,
+            10018754.17151941,
+            -10018754.171394622,
+            15028131.257279117,
+        ),
+    },
+    "zoom_10": {
+        "002R_002C": (0.0, -10018754.171394622, 10018754.171394622, 0.0),
+    },
+}
+
+
+def mock_grid_factory(grid_name: str) -> Mock:
+    tile_bounds = GRID_TILE_BOUNDS[grid_name]
+    grid = Mock()
+    grid.get_tile_ids.return_value = list(tile_bounds)
+    grid.get_tile_bounds.side_effect = tile_bounds.__getitem__
+    return grid
+
+
 @pytest.fixture(scope="module")
-def pixetl_imports():
+def resample_imports():
     secret_client = boto3.client(
         "secretsmanager", region_name=AWS_REGION, endpoint_url=AWS_SECRETSMANAGER_URL
     )
@@ -21,18 +76,28 @@ def pixetl_imports():
         SecretString="foosecret",  # pragma: allowlist secret
     )
 
-    from batch.python.resample import Bounds, intersecting_tiles
+    pixetl_module = ModuleType("gfw_pixetl")
+    grids_module = ModuleType("gfw_pixetl.grids")
+    grids_module.grid_factory = mock_grid_factory
+    pixetl_module.grids = grids_module
 
-    yield Bounds, intersecting_tiles
+    with patch.dict(
+        sys.modules,
+        {"gfw_pixetl": pixetl_module, "gfw_pixetl.grids": grids_module},
+    ):
+        from batch.python.resample import Bounds, intersecting_tiles
 
+        yield Bounds, intersecting_tiles
+
+    sys.modules.pop(MODULE_PATH_UNDER_TEST, None)
     secret_client.delete_secret(SecretId=AWS_GCS_KEY_SECRET_ARN)
 
 
-def test_intersecting_tiles_wm_same_crs_no_scaling_within_1_tile(pixetl_imports):
+def test_intersecting_tiles_wm_same_crs_no_scaling_within_1_tile(resample_imports):
     """Make sure that when we start with a (region slightly smaller than a) wm
     tile and look for intersecting tiles in the same zoom level we get just
     that tile."""
-    Bounds, intersecting_tiles = pixetl_imports
+    Bounds, intersecting_tiles = resample_imports
 
     source_crs = CRS.from_epsg(3857)
     src_tiles_info: List[Tuple[str, Any]] = [
@@ -73,11 +138,11 @@ def test_intersecting_tiles_wm_same_crs_no_scaling_within_1_tile(pixetl_imports)
     ]
 
 
-def test_intersecting_tiles_wm_same_crs_no_scaling_straddling_4_tiles(pixetl_imports):
+def test_intersecting_tiles_wm_same_crs_no_scaling_straddling_4_tiles(resample_imports):
     """Make sure that when we start with a region straddling the corner of 4 wm
     tiles and look for intersecting tiles in the same zoom level we get all
     4."""
-    Bounds, intersecting_tiles = pixetl_imports
+    Bounds, intersecting_tiles = resample_imports
 
     source_crs = CRS.from_epsg(3857)
     src_tiles_info: List[Tuple[str, Any]] = [
@@ -110,10 +175,10 @@ def test_intersecting_tiles_wm_same_crs_no_scaling_straddling_4_tiles(pixetl_imp
     assert expected_tile_ids == set([tile_info[0] for tile_info in result])
 
 
-def test_intersecting_tiles_wm_same_crs_zoom_out(pixetl_imports):
+def test_intersecting_tiles_wm_same_crs_zoom_out(resample_imports):
     """Also an area straddling the corners of 4 wm tiles, but this time target
     zoom level is one level out, turning those 4 into one tile."""
-    Bounds, intersecting_tiles = pixetl_imports
+    Bounds, intersecting_tiles = resample_imports
 
     source_crs = CRS.from_epsg(3857)
     src_tiles_info: List[Tuple[str, Any]] = [
@@ -146,9 +211,9 @@ def test_intersecting_tiles_wm_same_crs_zoom_out(pixetl_imports):
     assert expected_tile_ids == set([tile_info[0] for tile_info in result])
 
 
-def test_intersecting_tiles_epsg_4326_to_wm(pixetl_imports):
+def test_intersecting_tiles_epsg_4326_to_wm(resample_imports):
     """Go from a small epsg:4326 source tile to zoom level 10 tiles."""
-    Bounds, intersecting_tiles = pixetl_imports
+    Bounds, intersecting_tiles = resample_imports
 
     source_crs = CRS.from_epsg(4326)
     src_tiles_info: List[Tuple[str, Any]] = [

--- a/uv.lock
+++ b/uv.lock
@@ -614,10 +614,7 @@ dependencies = [
 dev = [
     { name = "asgi-lifespan" },
     { name = "docker" },
-    { name = "geopandas" },
-    { name = "gfw-pixetl" },
     { name = "moto", extra = ["awslambda", "batch", "ec2", "s3"] },
-    { name = "pandas" },
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -625,7 +622,6 @@ dev = [
     { name = "pytest-timeout" },
     { name = "pytest-unordered" },
     { name = "rasterio" },
-    { name = "retrying" },
 ]
 
 [package.metadata]
@@ -677,10 +673,7 @@ requires-dist = [
 dev = [
     { name = "asgi-lifespan" },
     { name = "docker" },
-    { name = "geopandas" },
-    { name = "gfw-pixetl", git = "https://github.com/wri/gfw_pixetl.git?branch=develop" },
     { name = "moto", extras = ["awslambda", "batch", "ec2", "s3", "secretsmanager"], specifier = "<5" },
-    { name = "pandas", specifier = "<2.2" },
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -688,13 +681,7 @@ dev = [
     { name = "pytest-timeout" },
     { name = "pytest-unordered", specifier = ">=0.6.1" },
     { name = "rasterio", specifier = "==1.4.3" },
-    { name = "retrying" },
 ]
-
-[[package]]
-name = "gfw-pixetl"
-version = "0.3.1"
-source = { git = "https://github.com/wri/gfw_pixetl.git?branch=develop#54dd12f453ec734d0afba94a31d81b3d584b64d1" }
 
 [[package]]
 name = "gino"


### PR DESCRIPTION
At some point I added a few tests for the resample script, which in Batch makes a small use of the PixETL code.
This necessitated adding it to the test dependencies, which was done. The problem is that then the resolved dependencies must accommodate BOTH the Data API AND PixETL. i.e. they become locked together, and it has become very difficult to upgrade either. But the resample script really uses just a little PixETL code, that for constructing grids.
In a previous PR I tried vendoring the grid code from PixETL but got no approvals and hated it anyway. This PR instead mocks the called PixETL functions which I like a lot more as a solution.